### PR TITLE
Add openscenario result files

### DIFF
--- a/reports/open_scenario/qc-result-CloseVehicleCrossing.xosc/Report.txt
+++ b/reports/open_scenario/qc-result-CloseVehicleCrossing.xosc/Report.txt
@@ -1,0 +1,76 @@
+====================================================================================================
+QC4OpenX - Pooled results
+====================================================================================================
+
+
+====================================================================================================
+    CheckerBundle:  xoscBundle
+    Build date:     2024-07-11
+    Build version:  0.1.0
+    Description:    OpenScenario checker bundle
+    Summary:        
+
+
+    Checker:        basic_xosc
+    Description:    Check if basic properties of input file are properly set
+    Status:         completed
+    Summary:        
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.0.0:xml.valid_xml_document
+
+    Checker:        schema_xosc
+    Description:    Check if xml properties of input file are properly set
+    Status:         completed
+    Summary:        
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.0.0:xml.valid_schema
+
+    Checker:        reference_xosc
+    Description:    Check if xml properties of input file are properly set
+    Status:         completed
+    Summary:        
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref
+        - rule:         asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_entity_references
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference
+
+    Checker:        parameters_xosc
+    Description:    Check if parameters properties of input file are properly set
+    Status:         completed
+    Summary:        
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs
+====================================================================================================
+
+Addressed vs Violated rules report 
+
+
+Total number of addressed rules:   9
+	-> Addressed RuleUID: asam.net:xosc:1.0.0:xml.valid_schema
+
+	-> Addressed RuleUID: asam.net:xosc:1.0.0:xml.valid_xml_document
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_entity_references
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions
+
+Total number of violated rules:    0
+====================================================================================================
+

--- a/reports/open_scenario/qc-result-CloseVehicleCrossing.xosc/Result.xqar
+++ b/reports/open_scenario/qc-result-CloseVehicleCrossing.xosc/Result.xqar
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<CheckerResults version="1.0.0">
+
+  <CheckerBundle build_date="2024-07-11" description="OpenScenario checker bundle" name="xoscBundle" summary="" version="0.1.0">
+    <Checker checkerId="basic_xosc" description="Check if basic properties of input file are properly set" status="completed" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_xml_document"/>
+    </Checker>
+    <Checker checkerId="schema_xosc" description="Check if xml properties of input file are properly set" status="completed" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_schema"/>
+    </Checker>
+    <Checker checkerId="reference_xosc" description="Check if xml properties of input file are properly set" status="completed" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference"/>
+    </Checker>
+    <Checker checkerId="parameters_xosc" description="Check if parameters properties of input file are properly set" status="completed" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs"/>
+    </Checker>
+  </CheckerBundle>
+
+</CheckerResults>

--- a/reports/open_scenario/qc-result-CloseVehicleCrossing.xosc/xosc_bundle_report.xqar
+++ b/reports/open_scenario/qc-result-CloseVehicleCrossing.xosc/xosc_bundle_report.xqar
@@ -1,0 +1,22 @@
+<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<CheckerResults version="0.1.0">
+  <CheckerBundle build_date="2024-07-11" description="OpenScenario checker bundle" name="xoscBundle" version="0.1.0" summary="">
+    <Checker status="completed" checkerId="basic_xosc" description="Check if basic properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_xml_document"/>
+    </Checker>
+    <Checker status="completed" checkerId="schema_xosc" description="Check if xml properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_schema"/>
+    </Checker>
+    <Checker status="completed" checkerId="reference_xosc" description="Check if xml properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference"/>
+    </Checker>
+    <Checker status="completed" checkerId="parameters_xosc" description="Check if parameters properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs"/>
+    </Checker>
+  </CheckerBundle>
+</CheckerResults>

--- a/reports/open_scenario/qc-result-CutIn.xosc/Report.txt
+++ b/reports/open_scenario/qc-result-CutIn.xosc/Report.txt
@@ -1,0 +1,76 @@
+====================================================================================================
+QC4OpenX - Pooled results
+====================================================================================================
+
+
+====================================================================================================
+    CheckerBundle:  xoscBundle
+    Build date:     2024-07-11
+    Build version:  0.1.0
+    Description:    OpenScenario checker bundle
+    Summary:        
+
+
+    Checker:        basic_xosc
+    Description:    Check if basic properties of input file are properly set
+    Status:         completed
+    Summary:        
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.0.0:xml.valid_xml_document
+
+    Checker:        schema_xosc
+    Description:    Check if xml properties of input file are properly set
+    Status:         completed
+    Summary:        
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.0.0:xml.valid_schema
+
+    Checker:        reference_xosc
+    Description:    Check if xml properties of input file are properly set
+    Status:         completed
+    Summary:        
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref
+        - rule:         asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_entity_references
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference
+
+    Checker:        parameters_xosc
+    Description:    Check if parameters properties of input file are properly set
+    Status:         completed
+    Summary:        
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs
+====================================================================================================
+
+Addressed vs Violated rules report 
+
+
+Total number of addressed rules:   9
+	-> Addressed RuleUID: asam.net:xosc:1.0.0:xml.valid_schema
+
+	-> Addressed RuleUID: asam.net:xosc:1.0.0:xml.valid_xml_document
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_entity_references
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions
+
+Total number of violated rules:    0
+====================================================================================================
+

--- a/reports/open_scenario/qc-result-CutIn.xosc/Result.xqar
+++ b/reports/open_scenario/qc-result-CutIn.xosc/Result.xqar
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<CheckerResults version="1.0.0">
+
+  <CheckerBundle build_date="2024-07-11" description="OpenScenario checker bundle" name="xoscBundle" summary="" version="0.1.0">
+    <Checker checkerId="basic_xosc" description="Check if basic properties of input file are properly set" status="completed" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_xml_document"/>
+    </Checker>
+    <Checker checkerId="schema_xosc" description="Check if xml properties of input file are properly set" status="completed" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_schema"/>
+    </Checker>
+    <Checker checkerId="reference_xosc" description="Check if xml properties of input file are properly set" status="completed" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference"/>
+    </Checker>
+    <Checker checkerId="parameters_xosc" description="Check if parameters properties of input file are properly set" status="completed" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs"/>
+    </Checker>
+  </CheckerBundle>
+
+</CheckerResults>

--- a/reports/open_scenario/qc-result-CutIn.xosc/xosc_bundle_report.xqar
+++ b/reports/open_scenario/qc-result-CutIn.xosc/xosc_bundle_report.xqar
@@ -1,0 +1,22 @@
+<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<CheckerResults version="0.1.0">
+  <CheckerBundle build_date="2024-07-11" description="OpenScenario checker bundle" name="xoscBundle" version="0.1.0" summary="">
+    <Checker status="completed" checkerId="basic_xosc" description="Check if basic properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_xml_document"/>
+    </Checker>
+    <Checker status="completed" checkerId="schema_xosc" description="Check if xml properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_schema"/>
+    </Checker>
+    <Checker status="completed" checkerId="reference_xosc" description="Check if xml properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference"/>
+    </Checker>
+    <Checker status="completed" checkerId="parameters_xosc" description="Check if parameters properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs"/>
+    </Checker>
+  </CheckerBundle>
+</CheckerResults>

--- a/reports/open_scenario/qc-result-DoubleLaneChanger.xosc/Report.txt
+++ b/reports/open_scenario/qc-result-DoubleLaneChanger.xosc/Report.txt
@@ -1,0 +1,76 @@
+====================================================================================================
+QC4OpenX - Pooled results
+====================================================================================================
+
+
+====================================================================================================
+    CheckerBundle:  xoscBundle
+    Build date:     2024-07-11
+    Build version:  0.1.0
+    Description:    OpenScenario checker bundle
+    Summary:        
+
+
+    Checker:        basic_xosc
+    Description:    Check if basic properties of input file are properly set
+    Status:         completed
+    Summary:        
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.0.0:xml.valid_xml_document
+
+    Checker:        schema_xosc
+    Description:    Check if xml properties of input file are properly set
+    Status:         completed
+    Summary:        
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.0.0:xml.valid_schema
+
+    Checker:        reference_xosc
+    Description:    Check if xml properties of input file are properly set
+    Status:         completed
+    Summary:        
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref
+        - rule:         asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_entity_references
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference
+
+    Checker:        parameters_xosc
+    Description:    Check if parameters properties of input file are properly set
+    Status:         completed
+    Summary:        
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs
+====================================================================================================
+
+Addressed vs Violated rules report 
+
+
+Total number of addressed rules:   9
+	-> Addressed RuleUID: asam.net:xosc:1.0.0:xml.valid_schema
+
+	-> Addressed RuleUID: asam.net:xosc:1.0.0:xml.valid_xml_document
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_entity_references
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions
+
+Total number of violated rules:    0
+====================================================================================================
+

--- a/reports/open_scenario/qc-result-DoubleLaneChanger.xosc/Result.xqar
+++ b/reports/open_scenario/qc-result-DoubleLaneChanger.xosc/Result.xqar
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<CheckerResults version="1.0.0">
+
+  <CheckerBundle build_date="2024-07-11" description="OpenScenario checker bundle" name="xoscBundle" summary="" version="0.1.0">
+    <Checker checkerId="basic_xosc" description="Check if basic properties of input file are properly set" status="completed" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_xml_document"/>
+    </Checker>
+    <Checker checkerId="schema_xosc" description="Check if xml properties of input file are properly set" status="completed" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_schema"/>
+    </Checker>
+    <Checker checkerId="reference_xosc" description="Check if xml properties of input file are properly set" status="completed" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference"/>
+    </Checker>
+    <Checker checkerId="parameters_xosc" description="Check if parameters properties of input file are properly set" status="completed" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs"/>
+    </Checker>
+  </CheckerBundle>
+
+</CheckerResults>

--- a/reports/open_scenario/qc-result-DoubleLaneChanger.xosc/xosc_bundle_report.xqar
+++ b/reports/open_scenario/qc-result-DoubleLaneChanger.xosc/xosc_bundle_report.xqar
@@ -1,0 +1,22 @@
+<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<CheckerResults version="0.1.0">
+  <CheckerBundle build_date="2024-07-11" description="OpenScenario checker bundle" name="xoscBundle" version="0.1.0" summary="">
+    <Checker status="completed" checkerId="basic_xosc" description="Check if basic properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_xml_document"/>
+    </Checker>
+    <Checker status="completed" checkerId="schema_xosc" description="Check if xml properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_schema"/>
+    </Checker>
+    <Checker status="completed" checkerId="reference_xosc" description="Check if xml properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference"/>
+    </Checker>
+    <Checker status="completed" checkerId="parameters_xosc" description="Check if parameters properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs"/>
+    </Checker>
+  </CheckerBundle>
+</CheckerResults>

--- a/reports/open_scenario/qc-result-EndOfTrafficJam.xosc/Report.txt
+++ b/reports/open_scenario/qc-result-EndOfTrafficJam.xosc/Report.txt
@@ -1,0 +1,76 @@
+====================================================================================================
+QC4OpenX - Pooled results
+====================================================================================================
+
+
+====================================================================================================
+    CheckerBundle:  xoscBundle
+    Build date:     2024-07-11
+    Build version:  0.1.0
+    Description:    OpenScenario checker bundle
+    Summary:        
+
+
+    Checker:        basic_xosc
+    Description:    Check if basic properties of input file are properly set
+    Status:         completed
+    Summary:        
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.0.0:xml.valid_xml_document
+
+    Checker:        schema_xosc
+    Description:    Check if xml properties of input file are properly set
+    Status:         completed
+    Summary:        
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.0.0:xml.valid_schema
+
+    Checker:        reference_xosc
+    Description:    Check if xml properties of input file are properly set
+    Status:         completed
+    Summary:        
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref
+        - rule:         asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_entity_references
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference
+
+    Checker:        parameters_xosc
+    Description:    Check if parameters properties of input file are properly set
+    Status:         completed
+    Summary:        
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs
+====================================================================================================
+
+Addressed vs Violated rules report 
+
+
+Total number of addressed rules:   9
+	-> Addressed RuleUID: asam.net:xosc:1.0.0:xml.valid_schema
+
+	-> Addressed RuleUID: asam.net:xosc:1.0.0:xml.valid_xml_document
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_entity_references
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions
+
+Total number of violated rules:    0
+====================================================================================================
+

--- a/reports/open_scenario/qc-result-EndOfTrafficJam.xosc/Result.xqar
+++ b/reports/open_scenario/qc-result-EndOfTrafficJam.xosc/Result.xqar
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<CheckerResults version="1.0.0">
+
+  <CheckerBundle build_date="2024-07-11" description="OpenScenario checker bundle" name="xoscBundle" summary="" version="0.1.0">
+    <Checker checkerId="basic_xosc" description="Check if basic properties of input file are properly set" status="completed" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_xml_document"/>
+    </Checker>
+    <Checker checkerId="schema_xosc" description="Check if xml properties of input file are properly set" status="completed" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_schema"/>
+    </Checker>
+    <Checker checkerId="reference_xosc" description="Check if xml properties of input file are properly set" status="completed" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference"/>
+    </Checker>
+    <Checker checkerId="parameters_xosc" description="Check if parameters properties of input file are properly set" status="completed" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs"/>
+    </Checker>
+  </CheckerBundle>
+
+</CheckerResults>

--- a/reports/open_scenario/qc-result-EndOfTrafficJam.xosc/xosc_bundle_report.xqar
+++ b/reports/open_scenario/qc-result-EndOfTrafficJam.xosc/xosc_bundle_report.xqar
@@ -1,0 +1,22 @@
+<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<CheckerResults version="0.1.0">
+  <CheckerBundle build_date="2024-07-11" description="OpenScenario checker bundle" name="xoscBundle" version="0.1.0" summary="">
+    <Checker status="completed" checkerId="basic_xosc" description="Check if basic properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_xml_document"/>
+    </Checker>
+    <Checker status="completed" checkerId="schema_xosc" description="Check if xml properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_schema"/>
+    </Checker>
+    <Checker status="completed" checkerId="reference_xosc" description="Check if xml properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference"/>
+    </Checker>
+    <Checker status="completed" checkerId="parameters_xosc" description="Check if parameters properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs"/>
+    </Checker>
+  </CheckerBundle>
+</CheckerResults>

--- a/reports/open_scenario/qc-result-EndofTrafficJamNeighboringLaneOccupied.xosc/Report.txt
+++ b/reports/open_scenario/qc-result-EndofTrafficJamNeighboringLaneOccupied.xosc/Report.txt
@@ -1,0 +1,81 @@
+====================================================================================================
+QC4OpenX - Pooled results
+====================================================================================================
+
+
+====================================================================================================
+    CheckerBundle:  xoscBundle
+    Build date:     2024-07-11
+    Build version:  0.1.0
+    Description:    OpenScenario checker bundle
+    Summary:        
+
+
+    Checker:        basic_xosc
+    Description:    Check if basic properties of input file are properly set
+    Status:         completed
+    Summary:        
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.0.0:xml.valid_xml_document
+
+    Checker:        schema_xosc
+    Description:    Check if xml properties of input file are properly set
+    Status:         completed
+    Summary:        
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.0.0:xml.valid_schema
+
+    Checker:        reference_xosc
+    Description:    Check if xml properties of input file are properly set
+    Status:         completed
+    Summary:        
+        Error:      #0: Issue flagging when an entity is referred in a entityRef attribute but it is not declared among Entities
+                    Entity at /OpenSCENARIO/Storyboard/Story/Act/ManeuverGroup/Maneuver/Event/StartTrigger/ConditionGroup/Condition/ByEntityCondition/TriggeringEntities/EntityRef with id name_in_global_scope not found among defined Entities 
+                       XPath: /OpenSCENARIO/Storyboard/Story/Act/ManeuverGroup/Maneuver/Event/StartTrigger/ConditionGroup/Condition/ByEntityCondition/TriggeringEntities/EntityRef
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref
+        - rule:         asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_entity_references
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference
+
+    Checker:        parameters_xosc
+    Description:    Check if parameters properties of input file are properly set
+    Status:         completed
+    Summary:        
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs
+====================================================================================================
+
+Addressed vs Violated rules report 
+
+
+Total number of addressed rules:   9
+	-> Addressed RuleUID: asam.net:xosc:1.0.0:xml.valid_schema
+
+	-> Addressed RuleUID: asam.net:xosc:1.0.0:xml.valid_xml_document
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_entity_references
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions
+
+Total number of violated rules:    1
+	-> Violated RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_entity_references
+
+====================================================================================================
+

--- a/reports/open_scenario/qc-result-EndofTrafficJamNeighboringLaneOccupied.xosc/Result.xqar
+++ b/reports/open_scenario/qc-result-EndofTrafficJamNeighboringLaneOccupied.xosc/Result.xqar
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<CheckerResults version="1.0.0">
+
+  <CheckerBundle build_date="2024-07-11" description="OpenScenario checker bundle" name="xoscBundle" summary="" version="0.1.0">
+    <Checker checkerId="basic_xosc" description="Check if basic properties of input file are properly set" status="completed" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_xml_document"/>
+    </Checker>
+    <Checker checkerId="schema_xosc" description="Check if xml properties of input file are properly set" status="completed" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_schema"/>
+    </Checker>
+    <Checker checkerId="reference_xosc" description="Check if xml properties of input file are properly set" status="completed" summary="">
+      <Issue description="Issue flagging when an entity is referred in a entityRef attribute but it is not declared among Entities" issueId="0" level="1" ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_entity_references">
+        <Locations description="Entity at /OpenSCENARIO/Storyboard/Story/Act/ManeuverGroup/Maneuver/Event/StartTrigger/ConditionGroup/Condition/ByEntityCondition/TriggeringEntities/EntityRef with id name_in_global_scope not found among defined Entities ">
+          <XMLLocation xpath="/OpenSCENARIO/Storyboard/Story/Act/ManeuverGroup/Maneuver/Event/StartTrigger/ConditionGroup/Condition/ByEntityCondition/TriggeringEntities/EntityRef"/>
+        </Locations>
+      </Issue>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference"/>
+    </Checker>
+    <Checker checkerId="parameters_xosc" description="Check if parameters properties of input file are properly set" status="completed" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs"/>
+    </Checker>
+  </CheckerBundle>
+
+</CheckerResults>

--- a/reports/open_scenario/qc-result-EndofTrafficJamNeighboringLaneOccupied.xosc/xosc_bundle_report.xqar
+++ b/reports/open_scenario/qc-result-EndofTrafficJamNeighboringLaneOccupied.xosc/xosc_bundle_report.xqar
@@ -1,0 +1,27 @@
+<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<CheckerResults version="0.1.0">
+  <CheckerBundle build_date="2024-07-11" description="OpenScenario checker bundle" name="xoscBundle" version="0.1.0" summary="">
+    <Checker status="completed" checkerId="basic_xosc" description="Check if basic properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_xml_document"/>
+    </Checker>
+    <Checker status="completed" checkerId="schema_xosc" description="Check if xml properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_schema"/>
+    </Checker>
+    <Checker status="completed" checkerId="reference_xosc" description="Check if xml properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference"/>
+      <Issue issueId="0" description="Issue flagging when an entity is referred in a entityRef attribute but it is not declared among Entities" level="1" ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_entity_references">
+        <Locations description="Entity at /OpenSCENARIO/Storyboard/Story/Act/ManeuverGroup/Maneuver/Event/StartTrigger/ConditionGroup/Condition/ByEntityCondition/TriggeringEntities/EntityRef with id name_in_global_scope not found among defined Entities ">
+          <XMLLocation xpath="/OpenSCENARIO/Storyboard/Story/Act/ManeuverGroup/Maneuver/Event/StartTrigger/ConditionGroup/Condition/ByEntityCondition/TriggeringEntities/EntityRef"/>
+        </Locations>
+      </Issue>
+    </Checker>
+    <Checker status="completed" checkerId="parameters_xosc" description="Check if parameters properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs"/>
+    </Checker>
+  </CheckerBundle>
+</CheckerResults>

--- a/reports/open_scenario/qc-result-Example_AniAction_LightAction_Veh_User.xosc/Report.txt
+++ b/reports/open_scenario/qc-result-Example_AniAction_LightAction_Veh_User.xosc/Report.txt
@@ -1,0 +1,81 @@
+====================================================================================================
+QC4OpenX - Pooled results
+====================================================================================================
+
+
+====================================================================================================
+    CheckerBundle:  xoscBundle
+    Build date:     2024-07-11
+    Build version:  0.1.0
+    Description:    OpenScenario checker bundle
+    Summary:        
+
+
+    Checker:        basic_xosc
+    Description:    Check if basic properties of input file are properly set
+    Status:         completed
+    Summary:        
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.0.0:xml.valid_xml_document
+
+    Checker:        schema_xosc
+    Description:    Check if xml properties of input file are properly set
+    Status:         completed
+    Summary:        
+        Error:      #0: Issue flagging when input file does not follow its version schema
+                    Element 'Storyboard': This element is not expected. Expected is one of ( ParameterDeclarations, VariableDeclarations, CatalogLocations, Catalog, ParameterValueDistribution ).
+                       File: row=5 column=0
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.0.0:xml.valid_schema
+
+    Checker:        reference_xosc
+    Description:    Check if xml properties of input file are properly set
+    Status:         completed
+    Summary:        
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref
+        - rule:         asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_entity_references
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference
+
+    Checker:        parameters_xosc
+    Description:    Check if parameters properties of input file are properly set
+    Status:         completed
+    Summary:        
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs
+====================================================================================================
+
+Addressed vs Violated rules report 
+
+
+Total number of addressed rules:   9
+	-> Addressed RuleUID: asam.net:xosc:1.0.0:xml.valid_schema
+
+	-> Addressed RuleUID: asam.net:xosc:1.0.0:xml.valid_xml_document
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_entity_references
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions
+
+Total number of violated rules:    1
+	-> Violated RuleUID: asam.net:xosc:1.0.0:xml.valid_schema
+
+====================================================================================================
+

--- a/reports/open_scenario/qc-result-Example_AniAction_LightAction_Veh_User.xosc/Result.xqar
+++ b/reports/open_scenario/qc-result-Example_AniAction_LightAction_Veh_User.xosc/Result.xqar
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<CheckerResults version="1.0.0">
+
+  <CheckerBundle build_date="2024-07-11" description="OpenScenario checker bundle" name="xoscBundle" summary="" version="0.1.0">
+    <Checker checkerId="basic_xosc" description="Check if basic properties of input file are properly set" status="completed" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_xml_document"/>
+    </Checker>
+    <Checker checkerId="schema_xosc" description="Check if xml properties of input file are properly set" status="completed" summary="">
+      <Issue description="Issue flagging when input file does not follow its version schema" issueId="0" level="1" ruleUID="asam.net:xosc:1.0.0:xml.valid_schema">
+        <Locations description="Element 'Storyboard': This element is not expected. Expected is one of ( ParameterDeclarations, VariableDeclarations, CatalogLocations, Catalog, ParameterValueDistribution ).">
+          <FileLocation column="0" row="5"/>
+        </Locations>
+      </Issue>
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_schema"/>
+    </Checker>
+    <Checker checkerId="reference_xosc" description="Check if xml properties of input file are properly set" status="completed" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference"/>
+    </Checker>
+    <Checker checkerId="parameters_xosc" description="Check if parameters properties of input file are properly set" status="completed" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs"/>
+    </Checker>
+  </CheckerBundle>
+
+</CheckerResults>

--- a/reports/open_scenario/qc-result-Example_AniAction_LightAction_Veh_User.xosc/xosc_bundle_report.xqar
+++ b/reports/open_scenario/qc-result-Example_AniAction_LightAction_Veh_User.xosc/xosc_bundle_report.xqar
@@ -1,0 +1,27 @@
+<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<CheckerResults version="0.1.0">
+  <CheckerBundle build_date="2024-07-11" description="OpenScenario checker bundle" name="xoscBundle" version="0.1.0" summary="">
+    <Checker status="completed" checkerId="basic_xosc" description="Check if basic properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_xml_document"/>
+    </Checker>
+    <Checker status="completed" checkerId="schema_xosc" description="Check if xml properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_schema"/>
+      <Issue issueId="0" description="Issue flagging when input file does not follow its version schema" level="1" ruleUID="asam.net:xosc:1.0.0:xml.valid_schema">
+        <Locations description="Element 'Storyboard': This element is not expected. Expected is one of ( ParameterDeclarations, VariableDeclarations, CatalogLocations, Catalog, ParameterValueDistribution ).">
+          <FileLocation column="0" row="5"/>
+        </Locations>
+      </Issue>
+    </Checker>
+    <Checker status="completed" checkerId="reference_xosc" description="Check if xml properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference"/>
+    </Checker>
+    <Checker status="completed" checkerId="parameters_xosc" description="Check if parameters properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs"/>
+    </Checker>
+  </CheckerBundle>
+</CheckerResults>

--- a/reports/open_scenario/qc-result-Example_Catalog_noName.xosc/Report.txt
+++ b/reports/open_scenario/qc-result-Example_Catalog_noName.xosc/Report.txt
@@ -1,0 +1,76 @@
+====================================================================================================
+QC4OpenX - Pooled results
+====================================================================================================
+
+
+====================================================================================================
+    CheckerBundle:  xoscBundle
+    Build date:     2024-07-11
+    Build version:  0.1.0
+    Description:    OpenScenario checker bundle
+    Summary:        
+
+
+    Checker:        basic_xosc
+    Description:    Check if basic properties of input file are properly set
+    Status:         completed
+    Summary:        
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.0.0:xml.valid_xml_document
+
+    Checker:        schema_xosc
+    Description:    Check if xml properties of input file are properly set
+    Status:         completed
+    Summary:        
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.0.0:xml.valid_schema
+
+    Checker:        reference_xosc
+    Description:    Check if xml properties of input file are properly set
+    Status:         completed
+    Summary:        
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref
+        - rule:         asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_entity_references
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference
+
+    Checker:        parameters_xosc
+    Description:    Check if parameters properties of input file are properly set
+    Status:         completed
+    Summary:        
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs
+====================================================================================================
+
+Addressed vs Violated rules report 
+
+
+Total number of addressed rules:   9
+	-> Addressed RuleUID: asam.net:xosc:1.0.0:xml.valid_schema
+
+	-> Addressed RuleUID: asam.net:xosc:1.0.0:xml.valid_xml_document
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_entity_references
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions
+
+Total number of violated rules:    0
+====================================================================================================
+

--- a/reports/open_scenario/qc-result-Example_Catalog_noName.xosc/Result.xqar
+++ b/reports/open_scenario/qc-result-Example_Catalog_noName.xosc/Result.xqar
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<CheckerResults version="1.0.0">
+
+  <CheckerBundle build_date="2024-07-11" description="OpenScenario checker bundle" name="xoscBundle" summary="" version="0.1.0">
+    <Checker checkerId="basic_xosc" description="Check if basic properties of input file are properly set" status="completed" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_xml_document"/>
+    </Checker>
+    <Checker checkerId="schema_xosc" description="Check if xml properties of input file are properly set" status="completed" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_schema"/>
+    </Checker>
+    <Checker checkerId="reference_xosc" description="Check if xml properties of input file are properly set" status="completed" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference"/>
+    </Checker>
+    <Checker checkerId="parameters_xosc" description="Check if parameters properties of input file are properly set" status="completed" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs"/>
+    </Checker>
+  </CheckerBundle>
+
+</CheckerResults>

--- a/reports/open_scenario/qc-result-Example_Catalog_noName.xosc/xosc_bundle_report.xqar
+++ b/reports/open_scenario/qc-result-Example_Catalog_noName.xosc/xosc_bundle_report.xqar
@@ -1,0 +1,22 @@
+<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<CheckerResults version="0.1.0">
+  <CheckerBundle build_date="2024-07-11" description="OpenScenario checker bundle" name="xoscBundle" version="0.1.0" summary="">
+    <Checker status="completed" checkerId="basic_xosc" description="Check if basic properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_xml_document"/>
+    </Checker>
+    <Checker status="completed" checkerId="schema_xosc" description="Check if xml properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_schema"/>
+    </Checker>
+    <Checker status="completed" checkerId="reference_xosc" description="Check if xml properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference"/>
+    </Checker>
+    <Checker status="completed" checkerId="parameters_xosc" description="Check if parameters properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs"/>
+    </Checker>
+  </CheckerBundle>
+</CheckerResults>

--- a/reports/open_scenario/qc-result-Example_Catalog_withName.xosc/Report.txt
+++ b/reports/open_scenario/qc-result-Example_Catalog_withName.xosc/Report.txt
@@ -1,0 +1,76 @@
+====================================================================================================
+QC4OpenX - Pooled results
+====================================================================================================
+
+
+====================================================================================================
+    CheckerBundle:  xoscBundle
+    Build date:     2024-07-11
+    Build version:  0.1.0
+    Description:    OpenScenario checker bundle
+    Summary:        
+
+
+    Checker:        basic_xosc
+    Description:    Check if basic properties of input file are properly set
+    Status:         completed
+    Summary:        
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.0.0:xml.valid_xml_document
+
+    Checker:        schema_xosc
+    Description:    Check if xml properties of input file are properly set
+    Status:         completed
+    Summary:        
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.0.0:xml.valid_schema
+
+    Checker:        reference_xosc
+    Description:    Check if xml properties of input file are properly set
+    Status:         completed
+    Summary:        
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref
+        - rule:         asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_entity_references
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference
+
+    Checker:        parameters_xosc
+    Description:    Check if parameters properties of input file are properly set
+    Status:         completed
+    Summary:        
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs
+====================================================================================================
+
+Addressed vs Violated rules report 
+
+
+Total number of addressed rules:   9
+	-> Addressed RuleUID: asam.net:xosc:1.0.0:xml.valid_schema
+
+	-> Addressed RuleUID: asam.net:xosc:1.0.0:xml.valid_xml_document
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_entity_references
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions
+
+Total number of violated rules:    0
+====================================================================================================
+

--- a/reports/open_scenario/qc-result-Example_Catalog_withName.xosc/Result.xqar
+++ b/reports/open_scenario/qc-result-Example_Catalog_withName.xosc/Result.xqar
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<CheckerResults version="1.0.0">
+
+  <CheckerBundle build_date="2024-07-11" description="OpenScenario checker bundle" name="xoscBundle" summary="" version="0.1.0">
+    <Checker checkerId="basic_xosc" description="Check if basic properties of input file are properly set" status="completed" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_xml_document"/>
+    </Checker>
+    <Checker checkerId="schema_xosc" description="Check if xml properties of input file are properly set" status="completed" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_schema"/>
+    </Checker>
+    <Checker checkerId="reference_xosc" description="Check if xml properties of input file are properly set" status="completed" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference"/>
+    </Checker>
+    <Checker checkerId="parameters_xosc" description="Check if parameters properties of input file are properly set" status="completed" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs"/>
+    </Checker>
+  </CheckerBundle>
+
+</CheckerResults>

--- a/reports/open_scenario/qc-result-Example_Catalog_withName.xosc/xosc_bundle_report.xqar
+++ b/reports/open_scenario/qc-result-Example_Catalog_withName.xosc/xosc_bundle_report.xqar
@@ -1,0 +1,22 @@
+<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<CheckerResults version="0.1.0">
+  <CheckerBundle build_date="2024-07-11" description="OpenScenario checker bundle" name="xoscBundle" version="0.1.0" summary="">
+    <Checker status="completed" checkerId="basic_xosc" description="Check if basic properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_xml_document"/>
+    </Checker>
+    <Checker status="completed" checkerId="schema_xosc" description="Check if xml properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_schema"/>
+    </Checker>
+    <Checker status="completed" checkerId="reference_xosc" description="Check if xml properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference"/>
+    </Checker>
+    <Checker status="completed" checkerId="parameters_xosc" description="Check if parameters properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs"/>
+    </Checker>
+  </CheckerBundle>
+</CheckerResults>

--- a/reports/open_scenario/qc-result-Example_ControllerAction.xosc/Report.txt
+++ b/reports/open_scenario/qc-result-Example_ControllerAction.xosc/Report.txt
@@ -1,0 +1,81 @@
+====================================================================================================
+QC4OpenX - Pooled results
+====================================================================================================
+
+
+====================================================================================================
+    CheckerBundle:  xoscBundle
+    Build date:     2024-07-11
+    Build version:  0.1.0
+    Description:    OpenScenario checker bundle
+    Summary:        
+
+
+    Checker:        basic_xosc
+    Description:    Check if basic properties of input file are properly set
+    Status:         completed
+    Summary:        
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.0.0:xml.valid_xml_document
+
+    Checker:        schema_xosc
+    Description:    Check if xml properties of input file are properly set
+    Status:         completed
+    Summary:        
+        Error:      #0: Issue flagging when input file does not follow its version schema
+                    Element 'Storyboard': This element is not expected. Expected is one of ( ParameterDeclarations, VariableDeclarations, CatalogLocations, Catalog, ParameterValueDistribution ).
+                       File: row=5 column=0
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.0.0:xml.valid_schema
+
+    Checker:        reference_xosc
+    Description:    Check if xml properties of input file are properly set
+    Status:         completed
+    Summary:        
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref
+        - rule:         asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_entity_references
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference
+
+    Checker:        parameters_xosc
+    Description:    Check if parameters properties of input file are properly set
+    Status:         completed
+    Summary:        
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs
+====================================================================================================
+
+Addressed vs Violated rules report 
+
+
+Total number of addressed rules:   9
+	-> Addressed RuleUID: asam.net:xosc:1.0.0:xml.valid_schema
+
+	-> Addressed RuleUID: asam.net:xosc:1.0.0:xml.valid_xml_document
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_entity_references
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions
+
+Total number of violated rules:    1
+	-> Violated RuleUID: asam.net:xosc:1.0.0:xml.valid_schema
+
+====================================================================================================
+

--- a/reports/open_scenario/qc-result-Example_ControllerAction.xosc/Result.xqar
+++ b/reports/open_scenario/qc-result-Example_ControllerAction.xosc/Result.xqar
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<CheckerResults version="1.0.0">
+
+  <CheckerBundle build_date="2024-07-11" description="OpenScenario checker bundle" name="xoscBundle" summary="" version="0.1.0">
+    <Checker checkerId="basic_xosc" description="Check if basic properties of input file are properly set" status="completed" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_xml_document"/>
+    </Checker>
+    <Checker checkerId="schema_xosc" description="Check if xml properties of input file are properly set" status="completed" summary="">
+      <Issue description="Issue flagging when input file does not follow its version schema" issueId="0" level="1" ruleUID="asam.net:xosc:1.0.0:xml.valid_schema">
+        <Locations description="Element 'Storyboard': This element is not expected. Expected is one of ( ParameterDeclarations, VariableDeclarations, CatalogLocations, Catalog, ParameterValueDistribution ).">
+          <FileLocation column="0" row="5"/>
+        </Locations>
+      </Issue>
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_schema"/>
+    </Checker>
+    <Checker checkerId="reference_xosc" description="Check if xml properties of input file are properly set" status="completed" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference"/>
+    </Checker>
+    <Checker checkerId="parameters_xosc" description="Check if parameters properties of input file are properly set" status="completed" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs"/>
+    </Checker>
+  </CheckerBundle>
+
+</CheckerResults>

--- a/reports/open_scenario/qc-result-Example_ControllerAction.xosc/xosc_bundle_report.xqar
+++ b/reports/open_scenario/qc-result-Example_ControllerAction.xosc/xosc_bundle_report.xqar
@@ -1,0 +1,27 @@
+<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<CheckerResults version="0.1.0">
+  <CheckerBundle build_date="2024-07-11" description="OpenScenario checker bundle" name="xoscBundle" version="0.1.0" summary="">
+    <Checker status="completed" checkerId="basic_xosc" description="Check if basic properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_xml_document"/>
+    </Checker>
+    <Checker status="completed" checkerId="schema_xosc" description="Check if xml properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_schema"/>
+      <Issue issueId="0" description="Issue flagging when input file does not follow its version schema" level="1" ruleUID="asam.net:xosc:1.0.0:xml.valid_schema">
+        <Locations description="Element 'Storyboard': This element is not expected. Expected is one of ( ParameterDeclarations, VariableDeclarations, CatalogLocations, Catalog, ParameterValueDistribution ).">
+          <FileLocation column="0" row="5"/>
+        </Locations>
+      </Issue>
+    </Checker>
+    <Checker status="completed" checkerId="reference_xosc" description="Check if xml properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference"/>
+    </Checker>
+    <Checker status="completed" checkerId="parameters_xosc" description="Check if parameters properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs"/>
+    </Checker>
+  </CheckerBundle>
+</CheckerResults>

--- a/reports/open_scenario/qc-result-Example_LightAction_User.xosc/Report.txt
+++ b/reports/open_scenario/qc-result-Example_LightAction_User.xosc/Report.txt
@@ -1,0 +1,81 @@
+====================================================================================================
+QC4OpenX - Pooled results
+====================================================================================================
+
+
+====================================================================================================
+    CheckerBundle:  xoscBundle
+    Build date:     2024-07-11
+    Build version:  0.1.0
+    Description:    OpenScenario checker bundle
+    Summary:        
+
+
+    Checker:        basic_xosc
+    Description:    Check if basic properties of input file are properly set
+    Status:         completed
+    Summary:        
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.0.0:xml.valid_xml_document
+
+    Checker:        schema_xosc
+    Description:    Check if xml properties of input file are properly set
+    Status:         completed
+    Summary:        
+        Error:      #0: Issue flagging when input file does not follow its version schema
+                    Element 'Storyboard': This element is not expected. Expected is one of ( ParameterDeclarations, VariableDeclarations, CatalogLocations, Catalog, ParameterValueDistribution ).
+                       File: row=5 column=0
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.0.0:xml.valid_schema
+
+    Checker:        reference_xosc
+    Description:    Check if xml properties of input file are properly set
+    Status:         completed
+    Summary:        
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref
+        - rule:         asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_entity_references
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference
+
+    Checker:        parameters_xosc
+    Description:    Check if parameters properties of input file are properly set
+    Status:         completed
+    Summary:        
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs
+====================================================================================================
+
+Addressed vs Violated rules report 
+
+
+Total number of addressed rules:   9
+	-> Addressed RuleUID: asam.net:xosc:1.0.0:xml.valid_schema
+
+	-> Addressed RuleUID: asam.net:xosc:1.0.0:xml.valid_xml_document
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_entity_references
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions
+
+Total number of violated rules:    1
+	-> Violated RuleUID: asam.net:xosc:1.0.0:xml.valid_schema
+
+====================================================================================================
+

--- a/reports/open_scenario/qc-result-Example_LightAction_User.xosc/Result.xqar
+++ b/reports/open_scenario/qc-result-Example_LightAction_User.xosc/Result.xqar
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<CheckerResults version="1.0.0">
+
+  <CheckerBundle build_date="2024-07-11" description="OpenScenario checker bundle" name="xoscBundle" summary="" version="0.1.0">
+    <Checker checkerId="basic_xosc" description="Check if basic properties of input file are properly set" status="completed" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_xml_document"/>
+    </Checker>
+    <Checker checkerId="schema_xosc" description="Check if xml properties of input file are properly set" status="completed" summary="">
+      <Issue description="Issue flagging when input file does not follow its version schema" issueId="0" level="1" ruleUID="asam.net:xosc:1.0.0:xml.valid_schema">
+        <Locations description="Element 'Storyboard': This element is not expected. Expected is one of ( ParameterDeclarations, VariableDeclarations, CatalogLocations, Catalog, ParameterValueDistribution ).">
+          <FileLocation column="0" row="5"/>
+        </Locations>
+      </Issue>
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_schema"/>
+    </Checker>
+    <Checker checkerId="reference_xosc" description="Check if xml properties of input file are properly set" status="completed" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference"/>
+    </Checker>
+    <Checker checkerId="parameters_xosc" description="Check if parameters properties of input file are properly set" status="completed" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs"/>
+    </Checker>
+  </CheckerBundle>
+
+</CheckerResults>

--- a/reports/open_scenario/qc-result-Example_LightAction_User.xosc/xosc_bundle_report.xqar
+++ b/reports/open_scenario/qc-result-Example_LightAction_User.xosc/xosc_bundle_report.xqar
@@ -1,0 +1,27 @@
+<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<CheckerResults version="0.1.0">
+  <CheckerBundle build_date="2024-07-11" description="OpenScenario checker bundle" name="xoscBundle" version="0.1.0" summary="">
+    <Checker status="completed" checkerId="basic_xosc" description="Check if basic properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_xml_document"/>
+    </Checker>
+    <Checker status="completed" checkerId="schema_xosc" description="Check if xml properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_schema"/>
+      <Issue issueId="0" description="Issue flagging when input file does not follow its version schema" level="1" ruleUID="asam.net:xosc:1.0.0:xml.valid_schema">
+        <Locations description="Element 'Storyboard': This element is not expected. Expected is one of ( ParameterDeclarations, VariableDeclarations, CatalogLocations, Catalog, ParameterValueDistribution ).">
+          <FileLocation column="0" row="5"/>
+        </Locations>
+      </Issue>
+    </Checker>
+    <Checker status="completed" checkerId="reference_xosc" description="Check if xml properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference"/>
+    </Checker>
+    <Checker status="completed" checkerId="parameters_xosc" description="Check if parameters properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs"/>
+    </Checker>
+  </CheckerBundle>
+</CheckerResults>

--- a/reports/open_scenario/qc-result-Example_LightAction_Veh.xosc/Report.txt
+++ b/reports/open_scenario/qc-result-Example_LightAction_Veh.xosc/Report.txt
@@ -1,0 +1,81 @@
+====================================================================================================
+QC4OpenX - Pooled results
+====================================================================================================
+
+
+====================================================================================================
+    CheckerBundle:  xoscBundle
+    Build date:     2024-07-11
+    Build version:  0.1.0
+    Description:    OpenScenario checker bundle
+    Summary:        
+
+
+    Checker:        basic_xosc
+    Description:    Check if basic properties of input file are properly set
+    Status:         completed
+    Summary:        
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.0.0:xml.valid_xml_document
+
+    Checker:        schema_xosc
+    Description:    Check if xml properties of input file are properly set
+    Status:         completed
+    Summary:        
+        Error:      #0: Issue flagging when input file does not follow its version schema
+                    Element 'Storyboard': This element is not expected. Expected is one of ( ParameterDeclarations, VariableDeclarations, CatalogLocations, Catalog, ParameterValueDistribution ).
+                       File: row=5 column=0
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.0.0:xml.valid_schema
+
+    Checker:        reference_xosc
+    Description:    Check if xml properties of input file are properly set
+    Status:         completed
+    Summary:        
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref
+        - rule:         asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_entity_references
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference
+
+    Checker:        parameters_xosc
+    Description:    Check if parameters properties of input file are properly set
+    Status:         completed
+    Summary:        
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs
+====================================================================================================
+
+Addressed vs Violated rules report 
+
+
+Total number of addressed rules:   9
+	-> Addressed RuleUID: asam.net:xosc:1.0.0:xml.valid_schema
+
+	-> Addressed RuleUID: asam.net:xosc:1.0.0:xml.valid_xml_document
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_entity_references
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions
+
+Total number of violated rules:    1
+	-> Violated RuleUID: asam.net:xosc:1.0.0:xml.valid_schema
+
+====================================================================================================
+

--- a/reports/open_scenario/qc-result-Example_LightAction_Veh.xosc/Result.xqar
+++ b/reports/open_scenario/qc-result-Example_LightAction_Veh.xosc/Result.xqar
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<CheckerResults version="1.0.0">
+
+  <CheckerBundle build_date="2024-07-11" description="OpenScenario checker bundle" name="xoscBundle" summary="" version="0.1.0">
+    <Checker checkerId="basic_xosc" description="Check if basic properties of input file are properly set" status="completed" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_xml_document"/>
+    </Checker>
+    <Checker checkerId="schema_xosc" description="Check if xml properties of input file are properly set" status="completed" summary="">
+      <Issue description="Issue flagging when input file does not follow its version schema" issueId="0" level="1" ruleUID="asam.net:xosc:1.0.0:xml.valid_schema">
+        <Locations description="Element 'Storyboard': This element is not expected. Expected is one of ( ParameterDeclarations, VariableDeclarations, CatalogLocations, Catalog, ParameterValueDistribution ).">
+          <FileLocation column="0" row="5"/>
+        </Locations>
+      </Issue>
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_schema"/>
+    </Checker>
+    <Checker checkerId="reference_xosc" description="Check if xml properties of input file are properly set" status="completed" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference"/>
+    </Checker>
+    <Checker checkerId="parameters_xosc" description="Check if parameters properties of input file are properly set" status="completed" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs"/>
+    </Checker>
+  </CheckerBundle>
+
+</CheckerResults>

--- a/reports/open_scenario/qc-result-Example_LightAction_Veh.xosc/xosc_bundle_report.xqar
+++ b/reports/open_scenario/qc-result-Example_LightAction_Veh.xosc/xosc_bundle_report.xqar
@@ -1,0 +1,27 @@
+<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<CheckerResults version="0.1.0">
+  <CheckerBundle build_date="2024-07-11" description="OpenScenario checker bundle" name="xoscBundle" version="0.1.0" summary="">
+    <Checker status="completed" checkerId="basic_xosc" description="Check if basic properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_xml_document"/>
+    </Checker>
+    <Checker status="completed" checkerId="schema_xosc" description="Check if xml properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_schema"/>
+      <Issue issueId="0" description="Issue flagging when input file does not follow its version schema" level="1" ruleUID="asam.net:xosc:1.0.0:xml.valid_schema">
+        <Locations description="Element 'Storyboard': This element is not expected. Expected is one of ( ParameterDeclarations, VariableDeclarations, CatalogLocations, Catalog, ParameterValueDistribution ).">
+          <FileLocation column="0" row="5"/>
+        </Locations>
+      </Issue>
+    </Checker>
+    <Checker status="completed" checkerId="reference_xosc" description="Check if xml properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference"/>
+    </Checker>
+    <Checker status="completed" checkerId="parameters_xosc" description="Check if parameters properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs"/>
+    </Checker>
+  </CheckerBundle>
+</CheckerResults>

--- a/reports/open_scenario/qc-result-Example_Phase.xosc/Report.txt
+++ b/reports/open_scenario/qc-result-Example_Phase.xosc/Report.txt
@@ -1,0 +1,81 @@
+====================================================================================================
+QC4OpenX - Pooled results
+====================================================================================================
+
+
+====================================================================================================
+    CheckerBundle:  xoscBundle
+    Build date:     2024-07-11
+    Build version:  0.1.0
+    Description:    OpenScenario checker bundle
+    Summary:        
+
+
+    Checker:        basic_xosc
+    Description:    Check if basic properties of input file are properly set
+    Status:         completed
+    Summary:        
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.0.0:xml.valid_xml_document
+
+    Checker:        schema_xosc
+    Description:    Check if xml properties of input file are properly set
+    Status:         completed
+    Summary:        
+        Error:      #0: Issue flagging when input file does not follow its version schema
+                    Element 'TrafficSignalController': This element is not expected. Expected is one of ( VariableDeclarations, MonitorDeclarations, CatalogLocations ).
+                       File: row=5 column=0
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.0.0:xml.valid_schema
+
+    Checker:        reference_xosc
+    Description:    Check if xml properties of input file are properly set
+    Status:         completed
+    Summary:        
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref
+        - rule:         asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_entity_references
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference
+
+    Checker:        parameters_xosc
+    Description:    Check if parameters properties of input file are properly set
+    Status:         completed
+    Summary:        
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs
+====================================================================================================
+
+Addressed vs Violated rules report 
+
+
+Total number of addressed rules:   9
+	-> Addressed RuleUID: asam.net:xosc:1.0.0:xml.valid_schema
+
+	-> Addressed RuleUID: asam.net:xosc:1.0.0:xml.valid_xml_document
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_entity_references
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions
+
+Total number of violated rules:    1
+	-> Violated RuleUID: asam.net:xosc:1.0.0:xml.valid_schema
+
+====================================================================================================
+

--- a/reports/open_scenario/qc-result-Example_Phase.xosc/Result.xqar
+++ b/reports/open_scenario/qc-result-Example_Phase.xosc/Result.xqar
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<CheckerResults version="1.0.0">
+
+  <CheckerBundle build_date="2024-07-11" description="OpenScenario checker bundle" name="xoscBundle" summary="" version="0.1.0">
+    <Checker checkerId="basic_xosc" description="Check if basic properties of input file are properly set" status="completed" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_xml_document"/>
+    </Checker>
+    <Checker checkerId="schema_xosc" description="Check if xml properties of input file are properly set" status="completed" summary="">
+      <Issue description="Issue flagging when input file does not follow its version schema" issueId="0" level="1" ruleUID="asam.net:xosc:1.0.0:xml.valid_schema">
+        <Locations description="Element 'TrafficSignalController': This element is not expected. Expected is one of ( VariableDeclarations, MonitorDeclarations, CatalogLocations ).">
+          <FileLocation column="0" row="5"/>
+        </Locations>
+      </Issue>
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_schema"/>
+    </Checker>
+    <Checker checkerId="reference_xosc" description="Check if xml properties of input file are properly set" status="completed" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference"/>
+    </Checker>
+    <Checker checkerId="parameters_xosc" description="Check if parameters properties of input file are properly set" status="completed" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs"/>
+    </Checker>
+  </CheckerBundle>
+
+</CheckerResults>

--- a/reports/open_scenario/qc-result-Example_Phase.xosc/xosc_bundle_report.xqar
+++ b/reports/open_scenario/qc-result-Example_Phase.xosc/xosc_bundle_report.xqar
@@ -1,0 +1,27 @@
+<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<CheckerResults version="0.1.0">
+  <CheckerBundle build_date="2024-07-11" description="OpenScenario checker bundle" name="xoscBundle" version="0.1.0" summary="">
+    <Checker status="completed" checkerId="basic_xosc" description="Check if basic properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_xml_document"/>
+    </Checker>
+    <Checker status="completed" checkerId="schema_xosc" description="Check if xml properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_schema"/>
+      <Issue issueId="0" description="Issue flagging when input file does not follow its version schema" level="1" ruleUID="asam.net:xosc:1.0.0:xml.valid_schema">
+        <Locations description="Element 'TrafficSignalController': This element is not expected. Expected is one of ( VariableDeclarations, MonitorDeclarations, CatalogLocations ).">
+          <FileLocation column="0" row="5"/>
+        </Locations>
+      </Issue>
+    </Checker>
+    <Checker status="completed" checkerId="reference_xosc" description="Check if xml properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference"/>
+    </Checker>
+    <Checker status="completed" checkerId="parameters_xosc" description="Check if parameters properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs"/>
+    </Checker>
+  </CheckerBundle>
+</CheckerResults>

--- a/reports/open_scenario/qc-result-Example_RoadPosition_NoOrientation.xosc/Report.txt
+++ b/reports/open_scenario/qc-result-Example_RoadPosition_NoOrientation.xosc/Report.txt
@@ -1,0 +1,81 @@
+====================================================================================================
+QC4OpenX - Pooled results
+====================================================================================================
+
+
+====================================================================================================
+    CheckerBundle:  xoscBundle
+    Build date:     2024-07-11
+    Build version:  0.1.0
+    Description:    OpenScenario checker bundle
+    Summary:        
+
+
+    Checker:        basic_xosc
+    Description:    Check if basic properties of input file are properly set
+    Status:         completed
+    Summary:        
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.0.0:xml.valid_xml_document
+
+    Checker:        schema_xosc
+    Description:    Check if xml properties of input file are properly set
+    Status:         completed
+    Summary:        
+        Error:      #0: Issue flagging when input file does not follow its version schema
+                    Element 'Storyboard': This element is not expected. Expected is one of ( ParameterDeclarations, VariableDeclarations, CatalogLocations, Catalog, ParameterValueDistribution ).
+                       File: row=5 column=0
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.0.0:xml.valid_schema
+
+    Checker:        reference_xosc
+    Description:    Check if xml properties of input file are properly set
+    Status:         completed
+    Summary:        
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref
+        - rule:         asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_entity_references
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference
+
+    Checker:        parameters_xosc
+    Description:    Check if parameters properties of input file are properly set
+    Status:         completed
+    Summary:        
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs
+====================================================================================================
+
+Addressed vs Violated rules report 
+
+
+Total number of addressed rules:   9
+	-> Addressed RuleUID: asam.net:xosc:1.0.0:xml.valid_schema
+
+	-> Addressed RuleUID: asam.net:xosc:1.0.0:xml.valid_xml_document
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_entity_references
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions
+
+Total number of violated rules:    1
+	-> Violated RuleUID: asam.net:xosc:1.0.0:xml.valid_schema
+
+====================================================================================================
+

--- a/reports/open_scenario/qc-result-Example_RoadPosition_NoOrientation.xosc/Result.xqar
+++ b/reports/open_scenario/qc-result-Example_RoadPosition_NoOrientation.xosc/Result.xqar
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<CheckerResults version="1.0.0">
+
+  <CheckerBundle build_date="2024-07-11" description="OpenScenario checker bundle" name="xoscBundle" summary="" version="0.1.0">
+    <Checker checkerId="basic_xosc" description="Check if basic properties of input file are properly set" status="completed" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_xml_document"/>
+    </Checker>
+    <Checker checkerId="schema_xosc" description="Check if xml properties of input file are properly set" status="completed" summary="">
+      <Issue description="Issue flagging when input file does not follow its version schema" issueId="0" level="1" ruleUID="asam.net:xosc:1.0.0:xml.valid_schema">
+        <Locations description="Element 'Storyboard': This element is not expected. Expected is one of ( ParameterDeclarations, VariableDeclarations, CatalogLocations, Catalog, ParameterValueDistribution ).">
+          <FileLocation column="0" row="5"/>
+        </Locations>
+      </Issue>
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_schema"/>
+    </Checker>
+    <Checker checkerId="reference_xosc" description="Check if xml properties of input file are properly set" status="completed" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference"/>
+    </Checker>
+    <Checker checkerId="parameters_xosc" description="Check if parameters properties of input file are properly set" status="completed" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs"/>
+    </Checker>
+  </CheckerBundle>
+
+</CheckerResults>

--- a/reports/open_scenario/qc-result-Example_RoadPosition_NoOrientation.xosc/xosc_bundle_report.xqar
+++ b/reports/open_scenario/qc-result-Example_RoadPosition_NoOrientation.xosc/xosc_bundle_report.xqar
@@ -1,0 +1,27 @@
+<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<CheckerResults version="0.1.0">
+  <CheckerBundle build_date="2024-07-11" description="OpenScenario checker bundle" name="xoscBundle" version="0.1.0" summary="">
+    <Checker status="completed" checkerId="basic_xosc" description="Check if basic properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_xml_document"/>
+    </Checker>
+    <Checker status="completed" checkerId="schema_xosc" description="Check if xml properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_schema"/>
+      <Issue issueId="0" description="Issue flagging when input file does not follow its version schema" level="1" ruleUID="asam.net:xosc:1.0.0:xml.valid_schema">
+        <Locations description="Element 'Storyboard': This element is not expected. Expected is one of ( ParameterDeclarations, VariableDeclarations, CatalogLocations, Catalog, ParameterValueDistribution ).">
+          <FileLocation column="0" row="5"/>
+        </Locations>
+      </Issue>
+    </Checker>
+    <Checker status="completed" checkerId="reference_xosc" description="Check if xml properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference"/>
+    </Checker>
+    <Checker status="completed" checkerId="parameters_xosc" description="Check if parameters properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs"/>
+    </Checker>
+  </CheckerBundle>
+</CheckerResults>

--- a/reports/open_scenario/qc-result-Example_RoadPosition_Orientation.xosc/Report.txt
+++ b/reports/open_scenario/qc-result-Example_RoadPosition_Orientation.xosc/Report.txt
@@ -1,0 +1,81 @@
+====================================================================================================
+QC4OpenX - Pooled results
+====================================================================================================
+
+
+====================================================================================================
+    CheckerBundle:  xoscBundle
+    Build date:     2024-07-11
+    Build version:  0.1.0
+    Description:    OpenScenario checker bundle
+    Summary:        
+
+
+    Checker:        basic_xosc
+    Description:    Check if basic properties of input file are properly set
+    Status:         completed
+    Summary:        
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.0.0:xml.valid_xml_document
+
+    Checker:        schema_xosc
+    Description:    Check if xml properties of input file are properly set
+    Status:         completed
+    Summary:        
+        Error:      #0: Issue flagging when input file does not follow its version schema
+                    Element 'Storyboard': This element is not expected. Expected is one of ( ParameterDeclarations, VariableDeclarations, CatalogLocations, Catalog, ParameterValueDistribution ).
+                       File: row=5 column=0
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.0.0:xml.valid_schema
+
+    Checker:        reference_xosc
+    Description:    Check if xml properties of input file are properly set
+    Status:         completed
+    Summary:        
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref
+        - rule:         asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_entity_references
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference
+
+    Checker:        parameters_xosc
+    Description:    Check if parameters properties of input file are properly set
+    Status:         completed
+    Summary:        
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs
+====================================================================================================
+
+Addressed vs Violated rules report 
+
+
+Total number of addressed rules:   9
+	-> Addressed RuleUID: asam.net:xosc:1.0.0:xml.valid_schema
+
+	-> Addressed RuleUID: asam.net:xosc:1.0.0:xml.valid_xml_document
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_entity_references
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions
+
+Total number of violated rules:    1
+	-> Violated RuleUID: asam.net:xosc:1.0.0:xml.valid_schema
+
+====================================================================================================
+

--- a/reports/open_scenario/qc-result-Example_RoadPosition_Orientation.xosc/Result.xqar
+++ b/reports/open_scenario/qc-result-Example_RoadPosition_Orientation.xosc/Result.xqar
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<CheckerResults version="1.0.0">
+
+  <CheckerBundle build_date="2024-07-11" description="OpenScenario checker bundle" name="xoscBundle" summary="" version="0.1.0">
+    <Checker checkerId="basic_xosc" description="Check if basic properties of input file are properly set" status="completed" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_xml_document"/>
+    </Checker>
+    <Checker checkerId="schema_xosc" description="Check if xml properties of input file are properly set" status="completed" summary="">
+      <Issue description="Issue flagging when input file does not follow its version schema" issueId="0" level="1" ruleUID="asam.net:xosc:1.0.0:xml.valid_schema">
+        <Locations description="Element 'Storyboard': This element is not expected. Expected is one of ( ParameterDeclarations, VariableDeclarations, CatalogLocations, Catalog, ParameterValueDistribution ).">
+          <FileLocation column="0" row="5"/>
+        </Locations>
+      </Issue>
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_schema"/>
+    </Checker>
+    <Checker checkerId="reference_xosc" description="Check if xml properties of input file are properly set" status="completed" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference"/>
+    </Checker>
+    <Checker checkerId="parameters_xosc" description="Check if parameters properties of input file are properly set" status="completed" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs"/>
+    </Checker>
+  </CheckerBundle>
+
+</CheckerResults>

--- a/reports/open_scenario/qc-result-Example_RoadPosition_Orientation.xosc/xosc_bundle_report.xqar
+++ b/reports/open_scenario/qc-result-Example_RoadPosition_Orientation.xosc/xosc_bundle_report.xqar
@@ -1,0 +1,27 @@
+<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<CheckerResults version="0.1.0">
+  <CheckerBundle build_date="2024-07-11" description="OpenScenario checker bundle" name="xoscBundle" version="0.1.0" summary="">
+    <Checker status="completed" checkerId="basic_xosc" description="Check if basic properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_xml_document"/>
+    </Checker>
+    <Checker status="completed" checkerId="schema_xosc" description="Check if xml properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_schema"/>
+      <Issue issueId="0" description="Issue flagging when input file does not follow its version schema" level="1" ruleUID="asam.net:xosc:1.0.0:xml.valid_schema">
+        <Locations description="Element 'Storyboard': This element is not expected. Expected is one of ( ParameterDeclarations, VariableDeclarations, CatalogLocations, Catalog, ParameterValueDistribution ).">
+          <FileLocation column="0" row="5"/>
+        </Locations>
+      </Issue>
+    </Checker>
+    <Checker status="completed" checkerId="reference_xosc" description="Check if xml properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference"/>
+    </Checker>
+    <Checker status="completed" checkerId="parameters_xosc" description="Check if parameters properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs"/>
+    </Checker>
+  </CheckerBundle>
+</CheckerResults>

--- a/reports/open_scenario/qc-result-FastOvertakeWithReInitialization.xosc/Report.txt
+++ b/reports/open_scenario/qc-result-FastOvertakeWithReInitialization.xosc/Report.txt
@@ -1,0 +1,76 @@
+====================================================================================================
+QC4OpenX - Pooled results
+====================================================================================================
+
+
+====================================================================================================
+    CheckerBundle:  xoscBundle
+    Build date:     2024-07-11
+    Build version:  0.1.0
+    Description:    OpenScenario checker bundle
+    Summary:        
+
+
+    Checker:        basic_xosc
+    Description:    Check if basic properties of input file are properly set
+    Status:         completed
+    Summary:        
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.0.0:xml.valid_xml_document
+
+    Checker:        schema_xosc
+    Description:    Check if xml properties of input file are properly set
+    Status:         completed
+    Summary:        
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.0.0:xml.valid_schema
+
+    Checker:        reference_xosc
+    Description:    Check if xml properties of input file are properly set
+    Status:         completed
+    Summary:        
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref
+        - rule:         asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_entity_references
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference
+
+    Checker:        parameters_xosc
+    Description:    Check if parameters properties of input file are properly set
+    Status:         completed
+    Summary:        
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs
+====================================================================================================
+
+Addressed vs Violated rules report 
+
+
+Total number of addressed rules:   9
+	-> Addressed RuleUID: asam.net:xosc:1.0.0:xml.valid_schema
+
+	-> Addressed RuleUID: asam.net:xosc:1.0.0:xml.valid_xml_document
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_entity_references
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions
+
+Total number of violated rules:    0
+====================================================================================================
+

--- a/reports/open_scenario/qc-result-FastOvertakeWithReInitialization.xosc/Result.xqar
+++ b/reports/open_scenario/qc-result-FastOvertakeWithReInitialization.xosc/Result.xqar
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<CheckerResults version="1.0.0">
+
+  <CheckerBundle build_date="2024-07-11" description="OpenScenario checker bundle" name="xoscBundle" summary="" version="0.1.0">
+    <Checker checkerId="basic_xosc" description="Check if basic properties of input file are properly set" status="completed" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_xml_document"/>
+    </Checker>
+    <Checker checkerId="schema_xosc" description="Check if xml properties of input file are properly set" status="completed" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_schema"/>
+    </Checker>
+    <Checker checkerId="reference_xosc" description="Check if xml properties of input file are properly set" status="completed" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference"/>
+    </Checker>
+    <Checker checkerId="parameters_xosc" description="Check if parameters properties of input file are properly set" status="completed" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs"/>
+    </Checker>
+  </CheckerBundle>
+
+</CheckerResults>

--- a/reports/open_scenario/qc-result-FastOvertakeWithReInitialization.xosc/xosc_bundle_report.xqar
+++ b/reports/open_scenario/qc-result-FastOvertakeWithReInitialization.xosc/xosc_bundle_report.xqar
@@ -1,0 +1,22 @@
+<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<CheckerResults version="0.1.0">
+  <CheckerBundle build_date="2024-07-11" description="OpenScenario checker bundle" name="xoscBundle" version="0.1.0" summary="">
+    <Checker status="completed" checkerId="basic_xosc" description="Check if basic properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_xml_document"/>
+    </Checker>
+    <Checker status="completed" checkerId="schema_xosc" description="Check if xml properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_schema"/>
+    </Checker>
+    <Checker status="completed" checkerId="reference_xosc" description="Check if xml properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference"/>
+    </Checker>
+    <Checker status="completed" checkerId="parameters_xosc" description="Check if parameters properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs"/>
+    </Checker>
+  </CheckerBundle>
+</CheckerResults>

--- a/reports/open_scenario/qc-result-Overtaker.xosc/Report.txt
+++ b/reports/open_scenario/qc-result-Overtaker.xosc/Report.txt
@@ -1,0 +1,76 @@
+====================================================================================================
+QC4OpenX - Pooled results
+====================================================================================================
+
+
+====================================================================================================
+    CheckerBundle:  xoscBundle
+    Build date:     2024-07-11
+    Build version:  0.1.0
+    Description:    OpenScenario checker bundle
+    Summary:        
+
+
+    Checker:        basic_xosc
+    Description:    Check if basic properties of input file are properly set
+    Status:         completed
+    Summary:        
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.0.0:xml.valid_xml_document
+
+    Checker:        schema_xosc
+    Description:    Check if xml properties of input file are properly set
+    Status:         completed
+    Summary:        
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.0.0:xml.valid_schema
+
+    Checker:        reference_xosc
+    Description:    Check if xml properties of input file are properly set
+    Status:         completed
+    Summary:        
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref
+        - rule:         asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_entity_references
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference
+
+    Checker:        parameters_xosc
+    Description:    Check if parameters properties of input file are properly set
+    Status:         completed
+    Summary:        
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs
+====================================================================================================
+
+Addressed vs Violated rules report 
+
+
+Total number of addressed rules:   9
+	-> Addressed RuleUID: asam.net:xosc:1.0.0:xml.valid_schema
+
+	-> Addressed RuleUID: asam.net:xosc:1.0.0:xml.valid_xml_document
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_entity_references
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions
+
+Total number of violated rules:    0
+====================================================================================================
+

--- a/reports/open_scenario/qc-result-Overtaker.xosc/Result.xqar
+++ b/reports/open_scenario/qc-result-Overtaker.xosc/Result.xqar
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<CheckerResults version="1.0.0">
+
+  <CheckerBundle build_date="2024-07-11" description="OpenScenario checker bundle" name="xoscBundle" summary="" version="0.1.0">
+    <Checker checkerId="basic_xosc" description="Check if basic properties of input file are properly set" status="completed" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_xml_document"/>
+    </Checker>
+    <Checker checkerId="schema_xosc" description="Check if xml properties of input file are properly set" status="completed" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_schema"/>
+    </Checker>
+    <Checker checkerId="reference_xosc" description="Check if xml properties of input file are properly set" status="completed" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference"/>
+    </Checker>
+    <Checker checkerId="parameters_xosc" description="Check if parameters properties of input file are properly set" status="completed" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs"/>
+    </Checker>
+  </CheckerBundle>
+
+</CheckerResults>

--- a/reports/open_scenario/qc-result-Overtaker.xosc/xosc_bundle_report.xqar
+++ b/reports/open_scenario/qc-result-Overtaker.xosc/xosc_bundle_report.xqar
@@ -1,0 +1,22 @@
+<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<CheckerResults version="0.1.0">
+  <CheckerBundle build_date="2024-07-11" description="OpenScenario checker bundle" name="xoscBundle" version="0.1.0" summary="">
+    <Checker status="completed" checkerId="basic_xosc" description="Check if basic properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_xml_document"/>
+    </Checker>
+    <Checker status="completed" checkerId="schema_xosc" description="Check if xml properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_schema"/>
+    </Checker>
+    <Checker status="completed" checkerId="reference_xosc" description="Check if xml properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference"/>
+    </Checker>
+    <Checker status="completed" checkerId="parameters_xosc" description="Check if parameters properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs"/>
+    </Checker>
+  </CheckerBundle>
+</CheckerResults>

--- a/reports/open_scenario/qc-result-RouteCatalog.xosc/Report.txt
+++ b/reports/open_scenario/qc-result-RouteCatalog.xosc/Report.txt
@@ -1,0 +1,76 @@
+====================================================================================================
+QC4OpenX - Pooled results
+====================================================================================================
+
+
+====================================================================================================
+    CheckerBundle:  xoscBundle
+    Build date:     2024-07-11
+    Build version:  0.1.0
+    Description:    OpenScenario checker bundle
+    Summary:        
+
+
+    Checker:        basic_xosc
+    Description:    Check if basic properties of input file are properly set
+    Status:         completed
+    Summary:        
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.0.0:xml.valid_xml_document
+
+    Checker:        schema_xosc
+    Description:    Check if xml properties of input file are properly set
+    Status:         completed
+    Summary:        
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.0.0:xml.valid_schema
+
+    Checker:        reference_xosc
+    Description:    Check if xml properties of input file are properly set
+    Status:         completed
+    Summary:        
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref
+        - rule:         asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_entity_references
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference
+
+    Checker:        parameters_xosc
+    Description:    Check if parameters properties of input file are properly set
+    Status:         completed
+    Summary:        
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs
+====================================================================================================
+
+Addressed vs Violated rules report 
+
+
+Total number of addressed rules:   9
+	-> Addressed RuleUID: asam.net:xosc:1.0.0:xml.valid_schema
+
+	-> Addressed RuleUID: asam.net:xosc:1.0.0:xml.valid_xml_document
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_entity_references
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions
+
+Total number of violated rules:    0
+====================================================================================================
+

--- a/reports/open_scenario/qc-result-RouteCatalog.xosc/Result.xqar
+++ b/reports/open_scenario/qc-result-RouteCatalog.xosc/Result.xqar
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<CheckerResults version="1.0.0">
+
+  <CheckerBundle build_date="2024-07-11" description="OpenScenario checker bundle" name="xoscBundle" summary="" version="0.1.0">
+    <Checker checkerId="basic_xosc" description="Check if basic properties of input file are properly set" status="completed" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_xml_document"/>
+    </Checker>
+    <Checker checkerId="schema_xosc" description="Check if xml properties of input file are properly set" status="completed" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_schema"/>
+    </Checker>
+    <Checker checkerId="reference_xosc" description="Check if xml properties of input file are properly set" status="completed" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference"/>
+    </Checker>
+    <Checker checkerId="parameters_xosc" description="Check if parameters properties of input file are properly set" status="completed" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs"/>
+    </Checker>
+  </CheckerBundle>
+
+</CheckerResults>

--- a/reports/open_scenario/qc-result-RouteCatalog.xosc/xosc_bundle_report.xqar
+++ b/reports/open_scenario/qc-result-RouteCatalog.xosc/xosc_bundle_report.xqar
@@ -1,0 +1,22 @@
+<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<CheckerResults version="0.1.0">
+  <CheckerBundle build_date="2024-07-11" description="OpenScenario checker bundle" name="xoscBundle" version="0.1.0" summary="">
+    <Checker status="completed" checkerId="basic_xosc" description="Check if basic properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_xml_document"/>
+    </Checker>
+    <Checker status="completed" checkerId="schema_xosc" description="Check if xml properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_schema"/>
+    </Checker>
+    <Checker status="completed" checkerId="reference_xosc" description="Check if xml properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference"/>
+    </Checker>
+    <Checker status="completed" checkerId="parameters_xosc" description="Check if parameters properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs"/>
+    </Checker>
+  </CheckerBundle>
+</CheckerResults>

--- a/reports/open_scenario/qc-result-SequentialEvents_0-100-0kph_Explicit.xosc/Report.txt
+++ b/reports/open_scenario/qc-result-SequentialEvents_0-100-0kph_Explicit.xosc/Report.txt
@@ -1,0 +1,76 @@
+====================================================================================================
+QC4OpenX - Pooled results
+====================================================================================================
+
+
+====================================================================================================
+    CheckerBundle:  xoscBundle
+    Build date:     2024-07-11
+    Build version:  0.1.0
+    Description:    OpenScenario checker bundle
+    Summary:        
+
+
+    Checker:        basic_xosc
+    Description:    Check if basic properties of input file are properly set
+    Status:         completed
+    Summary:        
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.0.0:xml.valid_xml_document
+
+    Checker:        schema_xosc
+    Description:    Check if xml properties of input file are properly set
+    Status:         completed
+    Summary:        
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.0.0:xml.valid_schema
+
+    Checker:        reference_xosc
+    Description:    Check if xml properties of input file are properly set
+    Status:         completed
+    Summary:        
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref
+        - rule:         asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_entity_references
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference
+
+    Checker:        parameters_xosc
+    Description:    Check if parameters properties of input file are properly set
+    Status:         completed
+    Summary:        
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs
+====================================================================================================
+
+Addressed vs Violated rules report 
+
+
+Total number of addressed rules:   9
+	-> Addressed RuleUID: asam.net:xosc:1.0.0:xml.valid_schema
+
+	-> Addressed RuleUID: asam.net:xosc:1.0.0:xml.valid_xml_document
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_entity_references
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions
+
+Total number of violated rules:    0
+====================================================================================================
+

--- a/reports/open_scenario/qc-result-SequentialEvents_0-100-0kph_Explicit.xosc/Result.xqar
+++ b/reports/open_scenario/qc-result-SequentialEvents_0-100-0kph_Explicit.xosc/Result.xqar
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<CheckerResults version="1.0.0">
+
+  <CheckerBundle build_date="2024-07-11" description="OpenScenario checker bundle" name="xoscBundle" summary="" version="0.1.0">
+    <Checker checkerId="basic_xosc" description="Check if basic properties of input file are properly set" status="completed" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_xml_document"/>
+    </Checker>
+    <Checker checkerId="schema_xosc" description="Check if xml properties of input file are properly set" status="completed" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_schema"/>
+    </Checker>
+    <Checker checkerId="reference_xosc" description="Check if xml properties of input file are properly set" status="completed" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference"/>
+    </Checker>
+    <Checker checkerId="parameters_xosc" description="Check if parameters properties of input file are properly set" status="completed" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs"/>
+    </Checker>
+  </CheckerBundle>
+
+</CheckerResults>

--- a/reports/open_scenario/qc-result-SequentialEvents_0-100-0kph_Explicit.xosc/xosc_bundle_report.xqar
+++ b/reports/open_scenario/qc-result-SequentialEvents_0-100-0kph_Explicit.xosc/xosc_bundle_report.xqar
@@ -1,0 +1,22 @@
+<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<CheckerResults version="0.1.0">
+  <CheckerBundle build_date="2024-07-11" description="OpenScenario checker bundle" name="xoscBundle" version="0.1.0" summary="">
+    <Checker status="completed" checkerId="basic_xosc" description="Check if basic properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_xml_document"/>
+    </Checker>
+    <Checker status="completed" checkerId="schema_xosc" description="Check if xml properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_schema"/>
+    </Checker>
+    <Checker status="completed" checkerId="reference_xosc" description="Check if xml properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference"/>
+    </Checker>
+    <Checker status="completed" checkerId="parameters_xosc" description="Check if parameters properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs"/>
+    </Checker>
+  </CheckerBundle>
+</CheckerResults>

--- a/reports/open_scenario/qc-result-SequentialEvents_0-100-0kph_Implicit.xosc/Report.txt
+++ b/reports/open_scenario/qc-result-SequentialEvents_0-100-0kph_Implicit.xosc/Report.txt
@@ -1,0 +1,76 @@
+====================================================================================================
+QC4OpenX - Pooled results
+====================================================================================================
+
+
+====================================================================================================
+    CheckerBundle:  xoscBundle
+    Build date:     2024-07-11
+    Build version:  0.1.0
+    Description:    OpenScenario checker bundle
+    Summary:        
+
+
+    Checker:        basic_xosc
+    Description:    Check if basic properties of input file are properly set
+    Status:         completed
+    Summary:        
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.0.0:xml.valid_xml_document
+
+    Checker:        schema_xosc
+    Description:    Check if xml properties of input file are properly set
+    Status:         completed
+    Summary:        
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.0.0:xml.valid_schema
+
+    Checker:        reference_xosc
+    Description:    Check if xml properties of input file are properly set
+    Status:         completed
+    Summary:        
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref
+        - rule:         asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_entity_references
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference
+
+    Checker:        parameters_xosc
+    Description:    Check if parameters properties of input file are properly set
+    Status:         completed
+    Summary:        
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs
+====================================================================================================
+
+Addressed vs Violated rules report 
+
+
+Total number of addressed rules:   9
+	-> Addressed RuleUID: asam.net:xosc:1.0.0:xml.valid_schema
+
+	-> Addressed RuleUID: asam.net:xosc:1.0.0:xml.valid_xml_document
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_entity_references
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions
+
+Total number of violated rules:    0
+====================================================================================================
+

--- a/reports/open_scenario/qc-result-SequentialEvents_0-100-0kph_Implicit.xosc/Result.xqar
+++ b/reports/open_scenario/qc-result-SequentialEvents_0-100-0kph_Implicit.xosc/Result.xqar
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<CheckerResults version="1.0.0">
+
+  <CheckerBundle build_date="2024-07-11" description="OpenScenario checker bundle" name="xoscBundle" summary="" version="0.1.0">
+    <Checker checkerId="basic_xosc" description="Check if basic properties of input file are properly set" status="completed" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_xml_document"/>
+    </Checker>
+    <Checker checkerId="schema_xosc" description="Check if xml properties of input file are properly set" status="completed" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_schema"/>
+    </Checker>
+    <Checker checkerId="reference_xosc" description="Check if xml properties of input file are properly set" status="completed" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference"/>
+    </Checker>
+    <Checker checkerId="parameters_xosc" description="Check if parameters properties of input file are properly set" status="completed" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs"/>
+    </Checker>
+  </CheckerBundle>
+
+</CheckerResults>

--- a/reports/open_scenario/qc-result-SequentialEvents_0-100-0kph_Implicit.xosc/xosc_bundle_report.xqar
+++ b/reports/open_scenario/qc-result-SequentialEvents_0-100-0kph_Implicit.xosc/xosc_bundle_report.xqar
@@ -1,0 +1,22 @@
+<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<CheckerResults version="0.1.0">
+  <CheckerBundle build_date="2024-07-11" description="OpenScenario checker bundle" name="xoscBundle" version="0.1.0" summary="">
+    <Checker status="completed" checkerId="basic_xosc" description="Check if basic properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_xml_document"/>
+    </Checker>
+    <Checker status="completed" checkerId="schema_xosc" description="Check if xml properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_schema"/>
+    </Checker>
+    <Checker status="completed" checkerId="reference_xosc" description="Check if xml properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference"/>
+    </Checker>
+    <Checker status="completed" checkerId="parameters_xosc" description="Check if parameters properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs"/>
+    </Checker>
+  </CheckerBundle>
+</CheckerResults>

--- a/reports/open_scenario/qc-result-SimpleOvertake.xosc/Report.txt
+++ b/reports/open_scenario/qc-result-SimpleOvertake.xosc/Report.txt
@@ -1,0 +1,76 @@
+====================================================================================================
+QC4OpenX - Pooled results
+====================================================================================================
+
+
+====================================================================================================
+    CheckerBundle:  xoscBundle
+    Build date:     2024-07-11
+    Build version:  0.1.0
+    Description:    OpenScenario checker bundle
+    Summary:        
+
+
+    Checker:        basic_xosc
+    Description:    Check if basic properties of input file are properly set
+    Status:         completed
+    Summary:        
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.0.0:xml.valid_xml_document
+
+    Checker:        schema_xosc
+    Description:    Check if xml properties of input file are properly set
+    Status:         completed
+    Summary:        
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.0.0:xml.valid_schema
+
+    Checker:        reference_xosc
+    Description:    Check if xml properties of input file are properly set
+    Status:         completed
+    Summary:        
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref
+        - rule:         asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_entity_references
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference
+
+    Checker:        parameters_xosc
+    Description:    Check if parameters properties of input file are properly set
+    Status:         completed
+    Summary:        
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs
+====================================================================================================
+
+Addressed vs Violated rules report 
+
+
+Total number of addressed rules:   9
+	-> Addressed RuleUID: asam.net:xosc:1.0.0:xml.valid_schema
+
+	-> Addressed RuleUID: asam.net:xosc:1.0.0:xml.valid_xml_document
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_entity_references
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions
+
+Total number of violated rules:    0
+====================================================================================================
+

--- a/reports/open_scenario/qc-result-SimpleOvertake.xosc/Result.xqar
+++ b/reports/open_scenario/qc-result-SimpleOvertake.xosc/Result.xqar
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<CheckerResults version="1.0.0">
+
+  <CheckerBundle build_date="2024-07-11" description="OpenScenario checker bundle" name="xoscBundle" summary="" version="0.1.0">
+    <Checker checkerId="basic_xosc" description="Check if basic properties of input file are properly set" status="completed" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_xml_document"/>
+    </Checker>
+    <Checker checkerId="schema_xosc" description="Check if xml properties of input file are properly set" status="completed" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_schema"/>
+    </Checker>
+    <Checker checkerId="reference_xosc" description="Check if xml properties of input file are properly set" status="completed" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference"/>
+    </Checker>
+    <Checker checkerId="parameters_xosc" description="Check if parameters properties of input file are properly set" status="completed" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs"/>
+    </Checker>
+  </CheckerBundle>
+
+</CheckerResults>

--- a/reports/open_scenario/qc-result-SimpleOvertake.xosc/xosc_bundle_report.xqar
+++ b/reports/open_scenario/qc-result-SimpleOvertake.xosc/xosc_bundle_report.xqar
@@ -1,0 +1,22 @@
+<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<CheckerResults version="0.1.0">
+  <CheckerBundle build_date="2024-07-11" description="OpenScenario checker bundle" name="xoscBundle" version="0.1.0" summary="">
+    <Checker status="completed" checkerId="basic_xosc" description="Check if basic properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_xml_document"/>
+    </Checker>
+    <Checker status="completed" checkerId="schema_xosc" description="Check if xml properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_schema"/>
+    </Checker>
+    <Checker status="completed" checkerId="reference_xosc" description="Check if xml properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference"/>
+    </Checker>
+    <Checker status="completed" checkerId="parameters_xosc" description="Check if parameters properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs"/>
+    </Checker>
+  </CheckerBundle>
+</CheckerResults>

--- a/reports/open_scenario/qc-result-SlowPrecedingVehicle.xosc/Report.txt
+++ b/reports/open_scenario/qc-result-SlowPrecedingVehicle.xosc/Report.txt
@@ -1,0 +1,76 @@
+====================================================================================================
+QC4OpenX - Pooled results
+====================================================================================================
+
+
+====================================================================================================
+    CheckerBundle:  xoscBundle
+    Build date:     2024-07-11
+    Build version:  0.1.0
+    Description:    OpenScenario checker bundle
+    Summary:        
+
+
+    Checker:        basic_xosc
+    Description:    Check if basic properties of input file are properly set
+    Status:         completed
+    Summary:        
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.0.0:xml.valid_xml_document
+
+    Checker:        schema_xosc
+    Description:    Check if xml properties of input file are properly set
+    Status:         completed
+    Summary:        
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.0.0:xml.valid_schema
+
+    Checker:        reference_xosc
+    Description:    Check if xml properties of input file are properly set
+    Status:         completed
+    Summary:        
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref
+        - rule:         asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_entity_references
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference
+
+    Checker:        parameters_xosc
+    Description:    Check if parameters properties of input file are properly set
+    Status:         completed
+    Summary:        
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs
+====================================================================================================
+
+Addressed vs Violated rules report 
+
+
+Total number of addressed rules:   9
+	-> Addressed RuleUID: asam.net:xosc:1.0.0:xml.valid_schema
+
+	-> Addressed RuleUID: asam.net:xosc:1.0.0:xml.valid_xml_document
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_entity_references
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions
+
+Total number of violated rules:    0
+====================================================================================================
+

--- a/reports/open_scenario/qc-result-SlowPrecedingVehicle.xosc/Result.xqar
+++ b/reports/open_scenario/qc-result-SlowPrecedingVehicle.xosc/Result.xqar
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<CheckerResults version="1.0.0">
+
+  <CheckerBundle build_date="2024-07-11" description="OpenScenario checker bundle" name="xoscBundle" summary="" version="0.1.0">
+    <Checker checkerId="basic_xosc" description="Check if basic properties of input file are properly set" status="completed" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_xml_document"/>
+    </Checker>
+    <Checker checkerId="schema_xosc" description="Check if xml properties of input file are properly set" status="completed" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_schema"/>
+    </Checker>
+    <Checker checkerId="reference_xosc" description="Check if xml properties of input file are properly set" status="completed" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference"/>
+    </Checker>
+    <Checker checkerId="parameters_xosc" description="Check if parameters properties of input file are properly set" status="completed" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs"/>
+    </Checker>
+  </CheckerBundle>
+
+</CheckerResults>

--- a/reports/open_scenario/qc-result-SlowPrecedingVehicle.xosc/xosc_bundle_report.xqar
+++ b/reports/open_scenario/qc-result-SlowPrecedingVehicle.xosc/xosc_bundle_report.xqar
@@ -1,0 +1,22 @@
+<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<CheckerResults version="0.1.0">
+  <CheckerBundle build_date="2024-07-11" description="OpenScenario checker bundle" name="xoscBundle" version="0.1.0" summary="">
+    <Checker status="completed" checkerId="basic_xosc" description="Check if basic properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_xml_document"/>
+    </Checker>
+    <Checker status="completed" checkerId="schema_xosc" description="Check if xml properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_schema"/>
+    </Checker>
+    <Checker status="completed" checkerId="reference_xosc" description="Check if xml properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference"/>
+    </Checker>
+    <Checker status="completed" checkerId="parameters_xosc" description="Check if parameters properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs"/>
+    </Checker>
+  </CheckerBundle>
+</CheckerResults>

--- a/reports/open_scenario/qc-result-SlowPrecedingVehicleDeterministicParameterSet.xosc/Report.txt
+++ b/reports/open_scenario/qc-result-SlowPrecedingVehicleDeterministicParameterSet.xosc/Report.txt
@@ -1,0 +1,76 @@
+====================================================================================================
+QC4OpenX - Pooled results
+====================================================================================================
+
+
+====================================================================================================
+    CheckerBundle:  xoscBundle
+    Build date:     2024-07-11
+    Build version:  0.1.0
+    Description:    OpenScenario checker bundle
+    Summary:        
+
+
+    Checker:        basic_xosc
+    Description:    Check if basic properties of input file are properly set
+    Status:         completed
+    Summary:        
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.0.0:xml.valid_xml_document
+
+    Checker:        schema_xosc
+    Description:    Check if xml properties of input file are properly set
+    Status:         completed
+    Summary:        
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.0.0:xml.valid_schema
+
+    Checker:        reference_xosc
+    Description:    Check if xml properties of input file are properly set
+    Status:         completed
+    Summary:        
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref
+        - rule:         asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_entity_references
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference
+
+    Checker:        parameters_xosc
+    Description:    Check if parameters properties of input file are properly set
+    Status:         completed
+    Summary:        
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs
+====================================================================================================
+
+Addressed vs Violated rules report 
+
+
+Total number of addressed rules:   9
+	-> Addressed RuleUID: asam.net:xosc:1.0.0:xml.valid_schema
+
+	-> Addressed RuleUID: asam.net:xosc:1.0.0:xml.valid_xml_document
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_entity_references
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions
+
+Total number of violated rules:    0
+====================================================================================================
+

--- a/reports/open_scenario/qc-result-SlowPrecedingVehicleDeterministicParameterSet.xosc/Result.xqar
+++ b/reports/open_scenario/qc-result-SlowPrecedingVehicleDeterministicParameterSet.xosc/Result.xqar
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<CheckerResults version="1.0.0">
+
+  <CheckerBundle build_date="2024-07-11" description="OpenScenario checker bundle" name="xoscBundle" summary="" version="0.1.0">
+    <Checker checkerId="basic_xosc" description="Check if basic properties of input file are properly set" status="completed" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_xml_document"/>
+    </Checker>
+    <Checker checkerId="schema_xosc" description="Check if xml properties of input file are properly set" status="completed" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_schema"/>
+    </Checker>
+    <Checker checkerId="reference_xosc" description="Check if xml properties of input file are properly set" status="completed" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference"/>
+    </Checker>
+    <Checker checkerId="parameters_xosc" description="Check if parameters properties of input file are properly set" status="completed" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs"/>
+    </Checker>
+  </CheckerBundle>
+
+</CheckerResults>

--- a/reports/open_scenario/qc-result-SlowPrecedingVehicleDeterministicParameterSet.xosc/xosc_bundle_report.xqar
+++ b/reports/open_scenario/qc-result-SlowPrecedingVehicleDeterministicParameterSet.xosc/xosc_bundle_report.xqar
@@ -1,0 +1,22 @@
+<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<CheckerResults version="0.1.0">
+  <CheckerBundle build_date="2024-07-11" description="OpenScenario checker bundle" name="xoscBundle" version="0.1.0" summary="">
+    <Checker status="completed" checkerId="basic_xosc" description="Check if basic properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_xml_document"/>
+    </Checker>
+    <Checker status="completed" checkerId="schema_xosc" description="Check if xml properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_schema"/>
+    </Checker>
+    <Checker status="completed" checkerId="reference_xosc" description="Check if xml properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference"/>
+    </Checker>
+    <Checker status="completed" checkerId="parameters_xosc" description="Check if parameters properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs"/>
+    </Checker>
+  </CheckerBundle>
+</CheckerResults>

--- a/reports/open_scenario/qc-result-SlowPrecedingVehicleStochasticParameterSet.xosc/Report.txt
+++ b/reports/open_scenario/qc-result-SlowPrecedingVehicleStochasticParameterSet.xosc/Report.txt
@@ -1,0 +1,76 @@
+====================================================================================================
+QC4OpenX - Pooled results
+====================================================================================================
+
+
+====================================================================================================
+    CheckerBundle:  xoscBundle
+    Build date:     2024-07-11
+    Build version:  0.1.0
+    Description:    OpenScenario checker bundle
+    Summary:        
+
+
+    Checker:        basic_xosc
+    Description:    Check if basic properties of input file are properly set
+    Status:         completed
+    Summary:        
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.0.0:xml.valid_xml_document
+
+    Checker:        schema_xosc
+    Description:    Check if xml properties of input file are properly set
+    Status:         completed
+    Summary:        
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.0.0:xml.valid_schema
+
+    Checker:        reference_xosc
+    Description:    Check if xml properties of input file are properly set
+    Status:         completed
+    Summary:        
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref
+        - rule:         asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_entity_references
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference
+
+    Checker:        parameters_xosc
+    Description:    Check if parameters properties of input file are properly set
+    Status:         completed
+    Summary:        
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs
+====================================================================================================
+
+Addressed vs Violated rules report 
+
+
+Total number of addressed rules:   9
+	-> Addressed RuleUID: asam.net:xosc:1.0.0:xml.valid_schema
+
+	-> Addressed RuleUID: asam.net:xosc:1.0.0:xml.valid_xml_document
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_entity_references
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions
+
+Total number of violated rules:    0
+====================================================================================================
+

--- a/reports/open_scenario/qc-result-SlowPrecedingVehicleStochasticParameterSet.xosc/Result.xqar
+++ b/reports/open_scenario/qc-result-SlowPrecedingVehicleStochasticParameterSet.xosc/Result.xqar
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<CheckerResults version="1.0.0">
+
+  <CheckerBundle build_date="2024-07-11" description="OpenScenario checker bundle" name="xoscBundle" summary="" version="0.1.0">
+    <Checker checkerId="basic_xosc" description="Check if basic properties of input file are properly set" status="completed" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_xml_document"/>
+    </Checker>
+    <Checker checkerId="schema_xosc" description="Check if xml properties of input file are properly set" status="completed" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_schema"/>
+    </Checker>
+    <Checker checkerId="reference_xosc" description="Check if xml properties of input file are properly set" status="completed" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference"/>
+    </Checker>
+    <Checker checkerId="parameters_xosc" description="Check if parameters properties of input file are properly set" status="completed" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs"/>
+    </Checker>
+  </CheckerBundle>
+
+</CheckerResults>

--- a/reports/open_scenario/qc-result-SlowPrecedingVehicleStochasticParameterSet.xosc/xosc_bundle_report.xqar
+++ b/reports/open_scenario/qc-result-SlowPrecedingVehicleStochasticParameterSet.xosc/xosc_bundle_report.xqar
@@ -1,0 +1,22 @@
+<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<CheckerResults version="0.1.0">
+  <CheckerBundle build_date="2024-07-11" description="OpenScenario checker bundle" name="xoscBundle" version="0.1.0" summary="">
+    <Checker status="completed" checkerId="basic_xosc" description="Check if basic properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_xml_document"/>
+    </Checker>
+    <Checker status="completed" checkerId="schema_xosc" description="Check if xml properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_schema"/>
+    </Checker>
+    <Checker status="completed" checkerId="reference_xosc" description="Check if xml properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference"/>
+    </Checker>
+    <Checker status="completed" checkerId="parameters_xosc" description="Check if parameters properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs"/>
+    </Checker>
+  </CheckerBundle>
+</CheckerResults>

--- a/reports/open_scenario/qc-result-SynchronizedArrivalToIntersection.xosc/Report.txt
+++ b/reports/open_scenario/qc-result-SynchronizedArrivalToIntersection.xosc/Report.txt
@@ -1,0 +1,76 @@
+====================================================================================================
+QC4OpenX - Pooled results
+====================================================================================================
+
+
+====================================================================================================
+    CheckerBundle:  xoscBundle
+    Build date:     2024-07-11
+    Build version:  0.1.0
+    Description:    OpenScenario checker bundle
+    Summary:        
+
+
+    Checker:        basic_xosc
+    Description:    Check if basic properties of input file are properly set
+    Status:         completed
+    Summary:        
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.0.0:xml.valid_xml_document
+
+    Checker:        schema_xosc
+    Description:    Check if xml properties of input file are properly set
+    Status:         completed
+    Summary:        
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.0.0:xml.valid_schema
+
+    Checker:        reference_xosc
+    Description:    Check if xml properties of input file are properly set
+    Status:         completed
+    Summary:        
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref
+        - rule:         asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_entity_references
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference
+
+    Checker:        parameters_xosc
+    Description:    Check if parameters properties of input file are properly set
+    Status:         completed
+    Summary:        
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs
+====================================================================================================
+
+Addressed vs Violated rules report 
+
+
+Total number of addressed rules:   9
+	-> Addressed RuleUID: asam.net:xosc:1.0.0:xml.valid_schema
+
+	-> Addressed RuleUID: asam.net:xosc:1.0.0:xml.valid_xml_document
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_entity_references
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions
+
+Total number of violated rules:    0
+====================================================================================================
+

--- a/reports/open_scenario/qc-result-SynchronizedArrivalToIntersection.xosc/Result.xqar
+++ b/reports/open_scenario/qc-result-SynchronizedArrivalToIntersection.xosc/Result.xqar
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<CheckerResults version="1.0.0">
+
+  <CheckerBundle build_date="2024-07-11" description="OpenScenario checker bundle" name="xoscBundle" summary="" version="0.1.0">
+    <Checker checkerId="basic_xosc" description="Check if basic properties of input file are properly set" status="completed" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_xml_document"/>
+    </Checker>
+    <Checker checkerId="schema_xosc" description="Check if xml properties of input file are properly set" status="completed" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_schema"/>
+    </Checker>
+    <Checker checkerId="reference_xosc" description="Check if xml properties of input file are properly set" status="completed" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference"/>
+    </Checker>
+    <Checker checkerId="parameters_xosc" description="Check if parameters properties of input file are properly set" status="completed" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs"/>
+    </Checker>
+  </CheckerBundle>
+
+</CheckerResults>

--- a/reports/open_scenario/qc-result-SynchronizedArrivalToIntersection.xosc/xosc_bundle_report.xqar
+++ b/reports/open_scenario/qc-result-SynchronizedArrivalToIntersection.xosc/xosc_bundle_report.xqar
@@ -1,0 +1,22 @@
+<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<CheckerResults version="0.1.0">
+  <CheckerBundle build_date="2024-07-11" description="OpenScenario checker bundle" name="xoscBundle" version="0.1.0" summary="">
+    <Checker status="completed" checkerId="basic_xosc" description="Check if basic properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_xml_document"/>
+    </Checker>
+    <Checker status="completed" checkerId="schema_xosc" description="Check if xml properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_schema"/>
+    </Checker>
+    <Checker status="completed" checkerId="reference_xosc" description="Check if xml properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference"/>
+    </Checker>
+    <Checker status="completed" checkerId="parameters_xosc" description="Check if parameters properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs"/>
+    </Checker>
+  </CheckerBundle>
+</CheckerResults>

--- a/reports/open_scenario/qc-result-TrafficJam.xosc/Report.txt
+++ b/reports/open_scenario/qc-result-TrafficJam.xosc/Report.txt
@@ -1,0 +1,76 @@
+====================================================================================================
+QC4OpenX - Pooled results
+====================================================================================================
+
+
+====================================================================================================
+    CheckerBundle:  xoscBundle
+    Build date:     2024-07-11
+    Build version:  0.1.0
+    Description:    OpenScenario checker bundle
+    Summary:        
+
+
+    Checker:        basic_xosc
+    Description:    Check if basic properties of input file are properly set
+    Status:         completed
+    Summary:        
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.0.0:xml.valid_xml_document
+
+    Checker:        schema_xosc
+    Description:    Check if xml properties of input file are properly set
+    Status:         completed
+    Summary:        
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.0.0:xml.valid_schema
+
+    Checker:        reference_xosc
+    Description:    Check if xml properties of input file are properly set
+    Status:         completed
+    Summary:        
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref
+        - rule:         asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_entity_references
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference
+
+    Checker:        parameters_xosc
+    Description:    Check if parameters properties of input file are properly set
+    Status:         completed
+    Summary:        
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs
+====================================================================================================
+
+Addressed vs Violated rules report 
+
+
+Total number of addressed rules:   9
+	-> Addressed RuleUID: asam.net:xosc:1.0.0:xml.valid_schema
+
+	-> Addressed RuleUID: asam.net:xosc:1.0.0:xml.valid_xml_document
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_entity_references
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions
+
+Total number of violated rules:    0
+====================================================================================================
+

--- a/reports/open_scenario/qc-result-TrafficJam.xosc/Result.xqar
+++ b/reports/open_scenario/qc-result-TrafficJam.xosc/Result.xqar
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<CheckerResults version="1.0.0">
+
+  <CheckerBundle build_date="2024-07-11" description="OpenScenario checker bundle" name="xoscBundle" summary="" version="0.1.0">
+    <Checker checkerId="basic_xosc" description="Check if basic properties of input file are properly set" status="completed" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_xml_document"/>
+    </Checker>
+    <Checker checkerId="schema_xosc" description="Check if xml properties of input file are properly set" status="completed" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_schema"/>
+    </Checker>
+    <Checker checkerId="reference_xosc" description="Check if xml properties of input file are properly set" status="completed" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference"/>
+    </Checker>
+    <Checker checkerId="parameters_xosc" description="Check if parameters properties of input file are properly set" status="completed" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs"/>
+    </Checker>
+  </CheckerBundle>
+
+</CheckerResults>

--- a/reports/open_scenario/qc-result-TrafficJam.xosc/xosc_bundle_report.xqar
+++ b/reports/open_scenario/qc-result-TrafficJam.xosc/xosc_bundle_report.xqar
@@ -1,0 +1,22 @@
+<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<CheckerResults version="0.1.0">
+  <CheckerBundle build_date="2024-07-11" description="OpenScenario checker bundle" name="xoscBundle" version="0.1.0" summary="">
+    <Checker status="completed" checkerId="basic_xosc" description="Check if basic properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_xml_document"/>
+    </Checker>
+    <Checker status="completed" checkerId="schema_xosc" description="Check if xml properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_schema"/>
+    </Checker>
+    <Checker status="completed" checkerId="reference_xosc" description="Check if xml properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference"/>
+    </Checker>
+    <Checker status="completed" checkerId="parameters_xosc" description="Check if parameters properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs"/>
+    </Checker>
+  </CheckerBundle>
+</CheckerResults>

--- a/reports/open_scenario/qc-result-TrailerConnect.xosc/Report.txt
+++ b/reports/open_scenario/qc-result-TrailerConnect.xosc/Report.txt
@@ -1,0 +1,76 @@
+====================================================================================================
+QC4OpenX - Pooled results
+====================================================================================================
+
+
+====================================================================================================
+    CheckerBundle:  xoscBundle
+    Build date:     2024-07-11
+    Build version:  0.1.0
+    Description:    OpenScenario checker bundle
+    Summary:        
+
+
+    Checker:        basic_xosc
+    Description:    Check if basic properties of input file are properly set
+    Status:         completed
+    Summary:        
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.0.0:xml.valid_xml_document
+
+    Checker:        schema_xosc
+    Description:    Check if xml properties of input file are properly set
+    Status:         completed
+    Summary:        
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.0.0:xml.valid_schema
+
+    Checker:        reference_xosc
+    Description:    Check if xml properties of input file are properly set
+    Status:         completed
+    Summary:        
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref
+        - rule:         asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_entity_references
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference
+
+    Checker:        parameters_xosc
+    Description:    Check if parameters properties of input file are properly set
+    Status:         completed
+    Summary:        
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs
+====================================================================================================
+
+Addressed vs Violated rules report 
+
+
+Total number of addressed rules:   9
+	-> Addressed RuleUID: asam.net:xosc:1.0.0:xml.valid_schema
+
+	-> Addressed RuleUID: asam.net:xosc:1.0.0:xml.valid_xml_document
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_entity_references
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions
+
+Total number of violated rules:    0
+====================================================================================================
+

--- a/reports/open_scenario/qc-result-TrailerConnect.xosc/Result.xqar
+++ b/reports/open_scenario/qc-result-TrailerConnect.xosc/Result.xqar
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<CheckerResults version="1.0.0">
+
+  <CheckerBundle build_date="2024-07-11" description="OpenScenario checker bundle" name="xoscBundle" summary="" version="0.1.0">
+    <Checker checkerId="basic_xosc" description="Check if basic properties of input file are properly set" status="completed" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_xml_document"/>
+    </Checker>
+    <Checker checkerId="schema_xosc" description="Check if xml properties of input file are properly set" status="completed" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_schema"/>
+    </Checker>
+    <Checker checkerId="reference_xosc" description="Check if xml properties of input file are properly set" status="completed" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference"/>
+    </Checker>
+    <Checker checkerId="parameters_xosc" description="Check if parameters properties of input file are properly set" status="completed" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs"/>
+    </Checker>
+  </CheckerBundle>
+
+</CheckerResults>

--- a/reports/open_scenario/qc-result-TrailerConnect.xosc/xosc_bundle_report.xqar
+++ b/reports/open_scenario/qc-result-TrailerConnect.xosc/xosc_bundle_report.xqar
@@ -1,0 +1,22 @@
+<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<CheckerResults version="0.1.0">
+  <CheckerBundle build_date="2024-07-11" description="OpenScenario checker bundle" name="xoscBundle" version="0.1.0" summary="">
+    <Checker status="completed" checkerId="basic_xosc" description="Check if basic properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_xml_document"/>
+    </Checker>
+    <Checker status="completed" checkerId="schema_xosc" description="Check if xml properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_schema"/>
+    </Checker>
+    <Checker status="completed" checkerId="reference_xosc" description="Check if xml properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference"/>
+    </Checker>
+    <Checker status="completed" checkerId="parameters_xosc" description="Check if parameters properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs"/>
+    </Checker>
+  </CheckerBundle>
+</CheckerResults>

--- a/reports/open_scenario/qc-result-TrajectoryCatalog.xosc/Report.txt
+++ b/reports/open_scenario/qc-result-TrajectoryCatalog.xosc/Report.txt
@@ -1,0 +1,76 @@
+====================================================================================================
+QC4OpenX - Pooled results
+====================================================================================================
+
+
+====================================================================================================
+    CheckerBundle:  xoscBundle
+    Build date:     2024-07-11
+    Build version:  0.1.0
+    Description:    OpenScenario checker bundle
+    Summary:        
+
+
+    Checker:        basic_xosc
+    Description:    Check if basic properties of input file are properly set
+    Status:         completed
+    Summary:        
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.0.0:xml.valid_xml_document
+
+    Checker:        schema_xosc
+    Description:    Check if xml properties of input file are properly set
+    Status:         completed
+    Summary:        
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.0.0:xml.valid_schema
+
+    Checker:        reference_xosc
+    Description:    Check if xml properties of input file are properly set
+    Status:         completed
+    Summary:        
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref
+        - rule:         asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_entity_references
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference
+
+    Checker:        parameters_xosc
+    Description:    Check if parameters properties of input file are properly set
+    Status:         completed
+    Summary:        
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs
+====================================================================================================
+
+Addressed vs Violated rules report 
+
+
+Total number of addressed rules:   9
+	-> Addressed RuleUID: asam.net:xosc:1.0.0:xml.valid_schema
+
+	-> Addressed RuleUID: asam.net:xosc:1.0.0:xml.valid_xml_document
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_entity_references
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions
+
+Total number of violated rules:    0
+====================================================================================================
+

--- a/reports/open_scenario/qc-result-TrajectoryCatalog.xosc/Result.xqar
+++ b/reports/open_scenario/qc-result-TrajectoryCatalog.xosc/Result.xqar
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<CheckerResults version="1.0.0">
+
+  <CheckerBundle build_date="2024-07-11" description="OpenScenario checker bundle" name="xoscBundle" summary="" version="0.1.0">
+    <Checker checkerId="basic_xosc" description="Check if basic properties of input file are properly set" status="completed" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_xml_document"/>
+    </Checker>
+    <Checker checkerId="schema_xosc" description="Check if xml properties of input file are properly set" status="completed" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_schema"/>
+    </Checker>
+    <Checker checkerId="reference_xosc" description="Check if xml properties of input file are properly set" status="completed" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference"/>
+    </Checker>
+    <Checker checkerId="parameters_xosc" description="Check if parameters properties of input file are properly set" status="completed" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs"/>
+    </Checker>
+  </CheckerBundle>
+
+</CheckerResults>

--- a/reports/open_scenario/qc-result-TrajectoryCatalog.xosc/xosc_bundle_report.xqar
+++ b/reports/open_scenario/qc-result-TrajectoryCatalog.xosc/xosc_bundle_report.xqar
@@ -1,0 +1,22 @@
+<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<CheckerResults version="0.1.0">
+  <CheckerBundle build_date="2024-07-11" description="OpenScenario checker bundle" name="xoscBundle" version="0.1.0" summary="">
+    <Checker status="completed" checkerId="basic_xosc" description="Check if basic properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_xml_document"/>
+    </Checker>
+    <Checker status="completed" checkerId="schema_xosc" description="Check if xml properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_schema"/>
+    </Checker>
+    <Checker status="completed" checkerId="reference_xosc" description="Check if xml properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference"/>
+    </Checker>
+    <Checker status="completed" checkerId="parameters_xosc" description="Check if parameters properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs"/>
+    </Checker>
+  </CheckerBundle>
+</CheckerResults>

--- a/reports/open_scenario/qc-result-VehicleCatalog.xosc/Report.txt
+++ b/reports/open_scenario/qc-result-VehicleCatalog.xosc/Report.txt
@@ -1,0 +1,76 @@
+====================================================================================================
+QC4OpenX - Pooled results
+====================================================================================================
+
+
+====================================================================================================
+    CheckerBundle:  xoscBundle
+    Build date:     2024-07-11
+    Build version:  0.1.0
+    Description:    OpenScenario checker bundle
+    Summary:        
+
+
+    Checker:        basic_xosc
+    Description:    Check if basic properties of input file are properly set
+    Status:         completed
+    Summary:        
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.0.0:xml.valid_xml_document
+
+    Checker:        schema_xosc
+    Description:    Check if xml properties of input file are properly set
+    Status:         completed
+    Summary:        
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.0.0:xml.valid_schema
+
+    Checker:        reference_xosc
+    Description:    Check if xml properties of input file are properly set
+    Status:         completed
+    Summary:        
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref
+        - rule:         asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_entity_references
+        - rule:         asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference
+
+    Checker:        parameters_xosc
+    Description:    Check if parameters properties of input file are properly set
+    Status:         completed
+    Summary:        
+
+        Addressed Rules:        
+        - rule:         asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs
+====================================================================================================
+
+Addressed vs Violated rules report 
+
+
+Total number of addressed rules:   9
+	-> Addressed RuleUID: asam.net:xosc:1.0.0:xml.valid_schema
+
+	-> Addressed RuleUID: asam.net:xosc:1.0.0:xml.valid_xml_document
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_entity_references
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references
+
+	-> Addressed RuleUID: asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions
+
+Total number of violated rules:    0
+====================================================================================================
+

--- a/reports/open_scenario/qc-result-VehicleCatalog.xosc/Result.xqar
+++ b/reports/open_scenario/qc-result-VehicleCatalog.xosc/Result.xqar
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<CheckerResults version="1.0.0">
+
+  <CheckerBundle build_date="2024-07-11" description="OpenScenario checker bundle" name="xoscBundle" summary="" version="0.1.0">
+    <Checker checkerId="basic_xosc" description="Check if basic properties of input file are properly set" status="completed" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_xml_document"/>
+    </Checker>
+    <Checker checkerId="schema_xosc" description="Check if xml properties of input file are properly set" status="completed" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_schema"/>
+    </Checker>
+    <Checker checkerId="reference_xosc" description="Check if xml properties of input file are properly set" status="completed" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference"/>
+    </Checker>
+    <Checker checkerId="parameters_xosc" description="Check if parameters properties of input file are properly set" status="completed" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs"/>
+    </Checker>
+  </CheckerBundle>
+
+</CheckerResults>

--- a/reports/open_scenario/qc-result-VehicleCatalog.xosc/xosc_bundle_report.xqar
+++ b/reports/open_scenario/qc-result-VehicleCatalog.xosc/xosc_bundle_report.xqar
@@ -1,0 +1,22 @@
+<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<CheckerResults version="0.1.0">
+  <CheckerBundle build_date="2024-07-11" description="OpenScenario checker bundle" name="xoscBundle" version="0.1.0" summary="">
+    <Checker status="completed" checkerId="basic_xosc" description="Check if basic properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_xml_document"/>
+    </Checker>
+    <Checker status="completed" checkerId="schema_xosc" description="Check if xml properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.0.0:xml.valid_schema"/>
+    </Checker>
+    <Checker status="completed" checkerId="reference_xosc" description="Check if xml properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.uniquely_resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_signal_id_in_traffic_signal_state_action"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_traffic_signal_controller_by_traffic_signal_controller_ref"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.valid_actor_reference_in_private_actions"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_entity_references"/>
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:reference_control.resolvable_variable_reference"/>
+    </Checker>
+    <Checker status="completed" checkerId="parameters_xosc" description="Check if parameters properties of input file are properly set" summary="">
+      <AddressedRule ruleUID="asam.net:xosc:1.2.0:parameters.valid_parameter_declaration_in_catalogs"/>
+    </Checker>
+  </CheckerBundle>
+</CheckerResults>


### PR DESCRIPTION
# Execution details:

**Date**
2024-07-11

**qc-openscenarioxml checkpoint**
https://github.com/asam-ev/qc-openscenarioxml/commit/4a936c53b756f55d321ecded4b705ce6e9ba2375

**Files analysed**: 
ASAM_OpenSCENARIO_v1.3.0_Examples from [this link](https://publications.pages.asam.net/standards/ASAM_OpenSCENARIO/ASAM_OpenSCENARIO_XML/latest/_attachments/generated/ASAM_OpenSCENARIO_v1.3.0_Examples.zip)

**Results**
From the input 28 xosc files:

- 20 presents 0 issues found
- 7 presents 1 issue found of rule `asam.net:xosc:1.0.0:xml.valid_schema`
  - `Example_AniAction_LightAction_Veh_User.xosc`
  - `Example_ControllerAction.xosc`
  - `Example_LightAction_User.xosc`
  - `Example_LightAction_Veh.xosc`
  - `Example_RoadPosition_NoOrientation.xosc`
  - `Example_RoadPosition_Orientation.xosc`
  All of the above present the same issue with the `Storyboard` node:
  ```
          Error:      #0: Issue flagging when input file does not follow its version schema
                    Element 'Storyboard': This element is not expected. Expected is one of ( ParameterDeclarations, VariableDeclarations, CatalogLocations, Catalog, ParameterValueDistribution ).
                       File: row=5 column=0
  ```
   - `Example_Phase.xosc`
   The `Example_Phase.xosc` present a schema validation issue on another node
   ```
   Error:      #0: Issue flagging when input file does not follow its version schema
                    Element 'TrafficSignalController': This element is not expected. Expected is one of ( VariableDeclarations, MonitorDeclarations, CatalogLocations ).
                       File: row=5 column=0
   ```
  
- 1 present 1 issue found of rule `asam.net:xosc:1.2.0:reference_control.resolvable_entity_references`
  - `EndofTrafficJamNeighboringLaneOccupied.xosc`
     In particular, the issue is about the resolution of `$owner` reference for a node of type `entityRef`:
     ```
        Error:      #0: Issue flagging when an entity is referred in a entityRef attribute but it is not declared among Entities
                    Entity at /OpenSCENARIO/Storyboard/Story/Act/ManeuverGroup/Maneuver/Event/StartTrigger/ConditionGroup/Condition/ByEntityCondition/TriggeringEntities/EntityRef with id name_in_global_scope not found among defined Entities 
                       XPath: /OpenSCENARIO/Storyboard/Story/Act/ManeuverGroup/Maneuver/Event/StartTrigger/ConditionGroup/Condition/ByEntityCondition/TriggeringEntities/EntityRef

     ```



